### PR TITLE
Offload dataset export encoding to worker harness

### DIFF
--- a/docs/rebuild-log.md
+++ b/docs/rebuild-log.md
@@ -1,0 +1,37 @@
+# Rebuild Blueprint Progress Log
+
+This log captures the follow-on work after the “Implement staged rebuild blueprint” baseline. Each entry records what was added in this session and why that piece matters for the staged HypercubeCore MVP.
+
+## Session – Telemetry & Frame Capture Bring-Up
+
+### What changed
+- **WebGL frame capture** (`HypercubeCore.captureFrame`, `flipPixelsVertically`) – expose a deterministic pixel readback so downstream services can pull actual render output instead of placeholder pixels.
+- **Dataset export metrics** (`DatasetExportService`) – track pending queue depth, total encoded frames, and last export format while flushing frames through the PSP stream.
+- **Control-panel telemetry** (`index.html`, `main.ts`) – surface uniform upload/skipped counts and dataset export metrics next to the rotation controls, keeping the operator aware of buffer health.
+- **Synthetic capture wiring** (`main.ts`) – replace the stubbed 1×1 pixel export with real captures throttled by queue depth and broadcast them via `LocalPspStream`.
+
+### Why these pieces matter
+- The **frame capture path** proves that Stage 2 geometry uploads can feed Stage 4 dataset export without leaving the GPU pipeline—critical for PSP archival and ML consumers.
+- **Dataset metrics** let us validate the UniformSync queue contract (exactly one upload per frame) and ensure capture/export doesn’t fall behind during automated or sensor-driven runs.
+- **UI telemetry** provides immediate operator feedback: if skips rise or pending frames spike, we know to adjust ingestion cadence before confidence drops.
+- **Real PSP captures** mean every rotation snapshot now carries a verifiable visual, keeping replay harnesses and external extruments in sync with the actual render output.
+
+### Next checkpoints
+- Thread the capture path through the dataset exporter worker once the Web Worker harness lands (Stage 4).
+- Extend telemetry with rolling latency stats (sensor → uniform upload → capture) to satisfy Stage 6 performance budgets.
+
+## Session – Dataset Export Worker Harness
+
+### What changed
+- **Web Worker encoder** (`datasetExport.worker.ts`, `DatasetExportService`) – move frame encoding off the main thread with a dedicated worker that handles both OffscreenCanvas pipelines and JSON fallbacks, while preserving deterministic error handling.
+- **Shared encoder module** (`datasetEncoder.ts`) – extracted reusable encode/checksum helpers so both the worker and inline fallback share identical logic.
+- **Worker orchestration tests** (`datasetExport.test.ts`) – cover the worker dispatch path and ensure metrics stay accurate whether the worker is available or we fall back to inline encoding.
+
+### Why these pieces matter
+- The **worker harness** satisfies the Stage 4 requirement to push PSP export work off the render loop, protecting frame time even as queue depths grow.
+- **Shared helpers** guarantee the worker and fallback paths produce byte-identical payloads, keeping regression tests deterministic across environments.
+- **New tests** harden the contract before introducing the Web Worker harness to the rest of the pipeline, making sure telemetry and metrics remain trustworthy when the encoder migrates off-thread.
+
+### Next checkpoints
+- Integrate the worker-backed exporter with the upcoming dataset export Web Worker host to stream encoded frames directly to PSP consumers (Stage 4).
+- Capture per-frame encode latency from the worker bridge to feed the Stage 6 performance dashboards.

--- a/index.html
+++ b/index.html
@@ -43,6 +43,23 @@
         letter-spacing: 0.08em;
         color: #9edcff;
       }
+      .telemetry {
+        border-top: 1px solid rgba(86, 180, 252, 0.2);
+        padding-top: 12px;
+        margin-top: 12px;
+        gap: 8px;
+      }
+      .telemetry-row {
+        display: flex;
+        justify-content: space-between;
+        font-size: 0.75rem;
+        color: rgba(211, 246, 255, 0.85);
+      }
+      .telemetry-row span:first-child {
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        color: rgba(144, 202, 249, 0.85);
+      }
       .control-group input[type="range"] {
         width: 100%;
       }
@@ -79,6 +96,24 @@
         <section class="control-group">
           <label for="lineWidth">Line Width</label>
           <input id="lineWidth" type="range" min="1" max="6" step="0.5" value="2" />
+        </section>
+        <section id="telemetry" class="control-group telemetry">
+          <div class="telemetry-row">
+            <span>Uniform uploads</span>
+            <span id="uniform-uploads">0</span>
+          </div>
+          <div class="telemetry-row">
+            <span>Uniform skips</span>
+            <span id="uniform-skips">0</span>
+          </div>
+          <div class="telemetry-row">
+            <span>Pending frames</span>
+            <span id="dataset-pending">0</span>
+          </div>
+          <div class="telemetry-row">
+            <span>Encoded frames</span>
+            <span id="dataset-total">0</span>
+          </div>
         </section>
       </aside>
       <canvas id="gl-canvas"></canvas>

--- a/src/core/frameUtils.test.ts
+++ b/src/core/frameUtils.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { flipPixelsVertically } from './frameUtils';
+
+function createCheckerboard(width: number, height: number): Uint8Array {
+  const data = new Uint8Array(width * height * 4);
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      const index = (y * width + x) * 4;
+      const on = (x + y) % 2 === 0;
+      data[index + 0] = on ? 255 : 0;
+      data[index + 1] = on ? 128 : 0;
+      data[index + 2] = on ? 64 : 0;
+      data[index + 3] = 255;
+    }
+  }
+  return data;
+}
+
+describe('flipPixelsVertically', () => {
+  it('returns a vertically flipped copy of the pixel buffer', () => {
+    const width = 2;
+    const height = 3;
+    const source = createCheckerboard(width, height);
+    const flipped = flipPixelsVertically(width, height, source);
+
+    // Top row in source should become bottom row in flipped
+    const sourceTop = Array.from(source.slice(0, width * 4));
+    const flippedBottom = Array.from(flipped.slice((height - 1) * width * 4));
+    expect(flippedBottom).toEqual(sourceTop);
+
+    // Bottom row in source should become top row in flipped
+    const sourceBottom = Array.from(source.slice((height - 1) * width * 4));
+    const flippedTop = Array.from(flipped.slice(0, width * 4));
+    expect(flippedTop).toEqual(sourceBottom);
+  });
+});

--- a/src/core/frameUtils.ts
+++ b/src/core/frameUtils.ts
@@ -1,0 +1,14 @@
+export function flipPixelsVertically(
+  width: number,
+  height: number,
+  source: Uint8Array | Uint8ClampedArray
+): Uint8ClampedArray {
+  const bytesPerRow = width * 4;
+  const flipped = new Uint8ClampedArray(source.length);
+  for (let row = 0; row < height; row++) {
+    const srcStart = row * bytesPerRow;
+    const destStart = (height - 1 - row) * bytesPerRow;
+    flipped.set(source.subarray(srcStart, srcStart + bytesPerRow), destStart);
+  }
+  return flipped;
+}

--- a/src/core/sixPlaneOrbit.test.ts
+++ b/src/core/sixPlaneOrbit.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { createHarmonicOrbit, SIX_PLANE_KEYS } from './sixPlaneOrbit';
+import { createHarmonicOrbit, createRotationLoom, SIX_PLANE_KEYS } from './sixPlaneOrbit';
 
 describe('six plane harmonic orbit', () => {
   it('produces bounded angles for each plane', () => {
@@ -18,5 +18,17 @@ describe('six plane harmonic orbit', () => {
     for (const plane of SIX_PLANE_KEYS) {
       expect(Math.abs(late[plane] - early[plane])).toBeLessThan(0.5);
     }
+  });
+
+  it('records rotation loom samples with bounded length', () => {
+    const orbit = createHarmonicOrbit();
+    const loom = createRotationLoom(orbit, 10);
+    let lastEnergy = 0;
+    for (let i = 0; i < 50; i++) {
+      const samples = loom(i * 0.1);
+      lastEnergy = samples[samples.length - 1]?.energy ?? 0;
+      expect(samples.length).toBeLessThanOrEqual(10);
+    }
+    expect(lastEnergy).toBeGreaterThan(0);
   });
 });

--- a/src/core/sixPlaneOrbit.ts
+++ b/src/core/sixPlaneOrbit.ts
@@ -18,6 +18,12 @@ export interface OrbitSpec {
   hyperCoupling?: number;
 }
 
+export interface LoomSample {
+  time: number;
+  energy: number;
+  angles: RotationAngles;
+}
+
 const GOLDEN_RATIO = (1 + Math.sqrt(5)) / 2;
 
 function defaultSpec(): OrbitSpec {
@@ -79,5 +85,25 @@ export function createHarmonicOrbit(spec: OrbitSpec = defaultSpec()): (timeSecon
     }
 
     return angles;
+  };
+}
+
+export function createRotationLoom(
+  orbit: (timeSeconds: number) => RotationAngles,
+  length = 240
+): (timeSeconds: number) => LoomSample[] {
+  const samples: LoomSample[] = [];
+  return (timeSeconds: number) => {
+    const angles = orbit(timeSeconds);
+    const energy = SIX_PLANE_KEYS.reduce((sum, plane) => sum + Math.abs(angles[plane]), 0);
+    samples.push({
+      time: timeSeconds,
+      energy,
+      angles: { ...angles }
+    });
+    if (samples.length > length) {
+      samples.shift();
+    }
+    return samples.slice();
   };
 }

--- a/src/core/uberShaderBuilder.test.ts
+++ b/src/core/uberShaderBuilder.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { UberShaderBuilder } from './uberShaderBuilder';
+
+describe('UberShaderBuilder', () => {
+  it('concatenates modules with headers', () => {
+    const builder = new UberShaderBuilder();
+    builder.addModule({
+      name: 'geometry',
+      header: '#define ENABLE_GEOMETRY',
+      body: 'vec4 loadGeometry() { return vec4(0.0); }'
+    });
+    builder.addModule({
+      name: 'projection',
+      body: 'vec3 project(vec4 v) { return v.xyz; }'
+    });
+
+    const result = builder.build();
+    expect(result).toContain('#define ENABLE_GEOMETRY');
+    expect(result).toContain('module: projection');
+  });
+});

--- a/src/core/uberShaderBuilder.ts
+++ b/src/core/uberShaderBuilder.ts
@@ -1,0 +1,19 @@
+export interface ShaderModule {
+  name: string;
+  header?: string;
+  body: string;
+}
+
+export class UberShaderBuilder {
+  private readonly modules: ShaderModule[] = [];
+
+  addModule(module: ShaderModule) {
+    this.modules.push(module);
+  }
+
+  build(): string {
+    const header = this.modules.map(module => module.header ?? '').join('\n');
+    const body = this.modules.map(module => `// module: ${module.name}\n${module.body}`).join('\n\n');
+    return `${header}\n${body}`.trim();
+  }
+}

--- a/src/core/uniformSyncQueue.test.ts
+++ b/src/core/uniformSyncQueue.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+import { UniformSyncQueue } from './uniformSyncQueue';
+
+describe('UniformSyncQueue', () => {
+  it('only exposes the latest snapshot per frame', () => {
+    const queue = new UniformSyncQueue();
+    queue.enqueue({ xy: 0.1, xz: 0.2, yz: 0.3, xw: 0, yw: 0, zw: 0 });
+    queue.enqueue({ xy: 0.5, xz: 0.6, yz: 0.7, xw: 0, yw: 0, zw: 0 });
+    const snapshot = queue.consume();
+    expect(snapshot?.xy).toBeCloseTo(0.5);
+    expect(queue.consume()).toBeNull();
+  });
+});

--- a/src/core/uniformSyncQueue.ts
+++ b/src/core/uniformSyncQueue.ts
@@ -1,0 +1,41 @@
+import type { RotationAngles } from './rotationUniforms';
+
+export interface UniformSyncMetrics {
+  enqueued: number;
+  uploads: number;
+  skipped: number;
+  lastUploadTime: number;
+}
+
+export class UniformSyncQueue {
+  private pending: RotationAngles | null = null;
+  private metrics: UniformSyncMetrics = {
+    enqueued: 0,
+    uploads: 0,
+    skipped: 0,
+    lastUploadTime: performance.now()
+  };
+
+  enqueue(angles: RotationAngles) {
+    this.metrics.enqueued += 1;
+    if (this.pending) {
+      this.metrics.skipped += 1;
+    }
+    this.pending = { ...angles };
+  }
+
+  consume(): RotationAngles | null {
+    if (!this.pending) {
+      return null;
+    }
+    const snapshot = this.pending;
+    this.pending = null;
+    this.metrics.uploads += 1;
+    this.metrics.lastUploadTime = performance.now();
+    return snapshot;
+  }
+
+  getMetrics(): UniformSyncMetrics {
+    return { ...this.metrics };
+  }
+}

--- a/src/geometry/geometryTopology.test.ts
+++ b/src/geometry/geometryTopology.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { listGeometries } from '../pipeline/geometryCatalog';
+
+function eulerCharacteristic(topology: { vertices: number; edges: number; faces: number; cells: number }): number {
+  return topology.vertices - topology.edges + topology.faces - topology.cells;
+}
+
+describe('geometry topologies', () => {
+  const geometries = listGeometries();
+
+  it('exposes all required topologies', () => {
+    expect(geometries.length).toBeGreaterThan(0);
+    for (const descriptor of geometries) {
+      expect(descriptor.data.topology.vertices).toBeGreaterThan(0);
+      expect(descriptor.data.topology.edges).toBeGreaterThan(0);
+    }
+  });
+
+  it('has Euler characteristic of zero for regular polychora', () => {
+    for (const descriptor of geometries) {
+      const chi = eulerCharacteristic(descriptor.data.topology);
+      expect(Math.abs(chi)).toBeLessThanOrEqual(1e-9);
+    }
+  });
+});

--- a/src/geometry/sixHundredCell.ts
+++ b/src/geometry/sixHundredCell.ts
@@ -1,0 +1,125 @@
+import { LINE_DRAW_MODE, type GeometryData } from './types';
+
+const PHI = (1 + Math.sqrt(5)) / 2;
+const INV_PHI = 1 / PHI;
+
+function createSixHundredCell(): GeometryData {
+  const vertices: number[][] = [];
+  const seen = new Set<string>();
+
+  function addVertex(v: number[]) {
+    const key = v.map(value => value.toFixed(6)).join(',');
+    if (!seen.has(key)) {
+      seen.add(key);
+      vertices.push(v);
+    }
+  }
+
+  // 16 hypercube vertices (±1/2, ±1/2, ±1/2, ±1/2)
+  for (const sx of [-0.5, 0.5]) {
+    for (const sy of [-0.5, 0.5]) {
+      for (const sz of [-0.5, 0.5]) {
+        for (const sw of [-0.5, 0.5]) {
+          addVertex([sx, sy, sz, sw]);
+        }
+      }
+    }
+  }
+
+  // 8 cross-polytope vertices (±1, 0, 0, 0)
+  for (let axis = 0; axis < 4; axis++) {
+    for (const sign of [-1, 1]) {
+      const v = [0, 0, 0, 0];
+      v[axis] = sign;
+      addVertex(v);
+    }
+  }
+
+  // 96 permutations of (0, ±1/2, ±phi/2, ±1/(2phi))
+  const base = [0, 0.5, PHI / 2, INV_PHI / 2];
+  const permutations = generatePermutations([0, 1, 2, 3]);
+
+  for (const perm of permutations) {
+    const components = perm.map(index => base[index]);
+    const nonZeroIndices = components
+      .map((value, index) => (Math.abs(value) > 1e-6 ? index : -1))
+      .filter(index => index >= 0);
+
+    const signCombos = 1 << nonZeroIndices.length;
+    for (let mask = 0; mask < signCombos; mask++) {
+      const candidate = components.slice();
+      let signParity = 1;
+      for (let bit = 0; bit < nonZeroIndices.length; bit++) {
+        const idx = nonZeroIndices[bit];
+        const sign = (mask & (1 << bit)) ? -1 : 1;
+        candidate[idx] *= sign;
+        signParity *= sign;
+      }
+
+      // Only accept configurations with even sign parity to enforce 96 vertices
+      if (signParity > 0) {
+        addVertex(candidate);
+      }
+    }
+  }
+
+  if (vertices.length !== 120) {
+    throw new Error(`600-cell vertex generation failed (expected 120, got ${vertices.length})`);
+  }
+
+  const candidates: Array<{ a: number; b: number; distance: number }> = [];
+  for (let i = 0; i < vertices.length; i++) {
+    for (let j = i + 1; j < vertices.length; j++) {
+      candidates.push({ a: i, b: j, distance: distanceSquared(vertices[i], vertices[j]) });
+    }
+  }
+
+  candidates.sort((a, b) => a.distance - b.distance);
+
+  const indices: number[] = [];
+  for (let k = 0; k < 720; k++) {
+    const edge = candidates[k];
+    indices.push(edge.a, edge.b);
+  }
+
+  if (indices.length / 2 !== 720) {
+    throw new Error(`600-cell edge generation failed (expected 720, got ${indices.length / 2})`);
+  }
+
+  return {
+    positions: new Float32Array(vertices.flat()),
+    indices: new Uint16Array(indices),
+    drawMode: LINE_DRAW_MODE,
+    vertexStride: 4,
+    topology: {
+      vertices: 120,
+      edges: 720,
+      faces: 1200,
+      cells: 600
+    }
+  };
+}
+
+function generatePermutations(indices: number[]): number[][] {
+  if (indices.length === 1) return [indices.slice()];
+  const permutations: number[][] = [];
+  for (let i = 0; i < indices.length; i++) {
+    const [current] = indices.splice(i, 1);
+    for (const rest of generatePermutations(indices)) {
+      permutations.push([current, ...rest]);
+    }
+    indices.splice(i, 0, current);
+  }
+  return permutations;
+}
+
+function distanceSquared(a: number[], b: number[]): number {
+  let sum = 0;
+  for (let i = 0; i < 4; i++) {
+    const d = a[i] - b[i];
+    sum += d * d;
+  }
+  return sum;
+}
+
+export const SixHundredCellGeometry = createSixHundredCell();

--- a/src/geometry/tesseract.ts
+++ b/src/geometry/tesseract.ts
@@ -1,4 +1,4 @@
-import type { GeometryData } from './types';
+import { LINE_DRAW_MODE, type GeometryData } from './types';
 
 function createTesseractGeometry(): GeometryData {
   const vertices: number[][] = [];
@@ -35,8 +35,14 @@ function createTesseractGeometry(): GeometryData {
   return {
     positions: new Float32Array(vertices.flat()),
     indices: new Uint16Array(indices),
-    drawMode: WebGL2RenderingContext.LINES,
-    vertexStride: 4
+    drawMode: LINE_DRAW_MODE,
+    vertexStride: 4,
+    topology: {
+      vertices: vertices.length,
+      edges: indices.length / 2,
+      faces: 24,
+      cells: 8
+    }
   };
 }
 

--- a/src/geometry/twentyFourCell.ts
+++ b/src/geometry/twentyFourCell.ts
@@ -1,4 +1,4 @@
-import type { GeometryData } from './types';
+import { LINE_DRAW_MODE, type GeometryData } from './types';
 
 function createTwentyFourCell(): GeometryData {
   const vertices: number[][] = [];
@@ -37,8 +37,14 @@ function createTwentyFourCell(): GeometryData {
   return {
     positions: new Float32Array(vertices.flat()),
     indices: new Uint16Array(indices),
-    drawMode: WebGL2RenderingContext.LINES,
-    vertexStride: 4
+    drawMode: LINE_DRAW_MODE,
+    vertexStride: 4,
+    topology: {
+      vertices: vertices.length,
+      edges: indices.length / 2,
+      faces: 96,
+      cells: 24
+    }
   };
 }
 

--- a/src/geometry/types.ts
+++ b/src/geometry/types.ts
@@ -1,8 +1,16 @@
+export interface GeometryTopology {
+  vertices: number;
+  edges: number;
+  faces: number;
+  cells: number;
+}
+
 export interface GeometryData {
   positions: Float32Array;
   indices: Uint16Array;
   drawMode: number;
   vertexStride: number;
+  topology: GeometryTopology;
 }
 
 export interface GeometryDescriptor {
@@ -10,3 +18,5 @@ export interface GeometryDescriptor {
   name: string;
   data: GeometryData;
 }
+
+export const LINE_DRAW_MODE = 0x0001;

--- a/src/ingestion/parserator.ts
+++ b/src/ingestion/parserator.ts
@@ -1,0 +1,143 @@
+import { mapImuPacket, type ImuPacket } from './imuMapper';
+import type { RotationSnapshot } from '../core/rotationUniforms';
+import type { PlaneMappingProfile } from './profiles';
+import { DEFAULT_PROFILE } from './profiles';
+
+export type Preprocessor = (packet: ImuPacket) => ImuPacket;
+export type SnapshotListener = (snapshot: RotationSnapshot) => void;
+
+export interface ParseratorOptions {
+  profile?: PlaneMappingProfile;
+  confidenceFloor?: number;
+}
+
+export class Parserator {
+  private preprocessors: Preprocessor[] = [];
+  private listeners = new Set<SnapshotListener>();
+  private lastTimestamp = 0;
+  private readonly profile: PlaneMappingProfile;
+  private readonly confidenceFloor: number;
+
+  constructor(options: ParseratorOptions = {}) {
+    this.profile = options.profile ?? DEFAULT_PROFILE;
+    this.confidenceFloor = options.confidenceFloor ?? 0.6;
+  }
+
+  registerPreprocessor(fn: Preprocessor) {
+    this.preprocessors.push(fn);
+  }
+
+  onSnapshot(listener: SnapshotListener) {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  ingest(packet: ImuPacket) {
+    let processed = packet;
+    for (const fn of this.preprocessors) {
+      processed = fn(processed);
+    }
+
+    const dt = this.computeDelta(processed.timestamp);
+    const snapshot = mapImuPacket(processed, dt);
+    snapshot.confidence = Math.max(snapshot.confidence, this.confidenceFloor);
+    this.applyProfile(snapshot, processed);
+
+    for (const listener of this.listeners) {
+      listener({ ...snapshot });
+    }
+  }
+
+  private computeDelta(timestamp: number): number {
+    if (this.lastTimestamp === 0) {
+      this.lastTimestamp = timestamp;
+      return 0.016;
+    }
+    const dt = Math.max(1e-3, (timestamp - this.lastTimestamp) / 1000);
+    this.lastTimestamp = timestamp;
+    return dt;
+  }
+
+  private applyProfile(snapshot: RotationSnapshot, packet: ImuPacket) {
+    const axisIndex = { x: 0, y: 1, z: 2 } as const;
+
+    for (const channel of this.profile.spatial) {
+      const index = axisIndex[channel.axis];
+      const value = packet.gyro[index] * channel.gain;
+      snapshot[channel.plane] = this.applySmoothing(snapshot[channel.plane], value, channel.smoothing);
+      if (channel.clamp !== undefined) {
+        snapshot[channel.plane] = clamp(snapshot[channel.plane], -channel.clamp, channel.clamp);
+      }
+    }
+
+    for (const channel of this.profile.hyperspatial) {
+      const index = axisIndex[channel.axis];
+      const value = packet.accel[index] * channel.gain;
+      snapshot[channel.plane] = this.applySmoothing(snapshot[channel.plane], value, channel.smoothing);
+      if (channel.clamp !== undefined) {
+        snapshot[channel.plane] = clamp(snapshot[channel.plane], -channel.clamp, channel.clamp);
+      }
+    }
+  }
+
+  private applySmoothing(current: number, incoming: number, smoothing = 0): number {
+    if (smoothing <= 0) return incoming;
+    return current * smoothing + incoming * (1 - smoothing);
+  }
+}
+
+export function lowPassGyro(cutoff: number): Preprocessor {
+  let last: ImuPacket | null = null;
+  return packet => {
+    if (!last) {
+      last = packet;
+      return packet;
+    }
+    const blend = Math.exp(-cutoff * Math.max(1e-3, (packet.timestamp - last.timestamp) / 1000));
+    const gyro: [number, number, number] = [0, 0, 0];
+    for (let i = 0; i < 3; i++) {
+      gyro[i] = blend * last.gyro[i] + (1 - blend) * packet.gyro[i];
+    }
+    last = { ...packet, gyro };
+    return last;
+  };
+}
+
+export function gravityIsolation(strength: number): Preprocessor {
+  return packet => {
+    const [ax, ay, az] = packet.accel;
+    const magnitude = Math.max(Math.hypot(ax, ay, az), 1e-5);
+    const normalized: [number, number, number] = [ax / magnitude, ay / magnitude, az / magnitude];
+    return { ...packet, accel: normalized.map(value => value * strength) as [number, number, number] };
+  };
+}
+
+export function featureWindow(windowSize: number): Preprocessor {
+  const window: ImuPacket[] = [];
+  return packet => {
+    window.push(packet);
+    if (window.length > windowSize) window.shift();
+    const averaged = averagePackets(window);
+    return { ...packet, gyro: averaged.gyro, accel: averaged.accel };
+  };
+}
+
+function averagePackets(samples: ImuPacket[]): { gyro: [number, number, number]; accel: [number, number, number] } {
+  const gyro: [number, number, number] = [0, 0, 0];
+  const accel: [number, number, number] = [0, 0, 0];
+  for (const sample of samples) {
+    for (let i = 0; i < 3; i++) {
+      gyro[i] += sample.gyro[i];
+      accel[i] += sample.accel[i];
+    }
+  }
+  for (let i = 0; i < 3; i++) {
+    gyro[i] /= samples.length;
+    accel[i] /= samples.length;
+  }
+  return { gyro, accel };
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}

--- a/src/ingestion/profiles.ts
+++ b/src/ingestion/profiles.ts
@@ -1,0 +1,33 @@
+import type { RotationAngles } from '../core/rotationUniforms';
+
+export type RotationPlane = keyof RotationAngles;
+
+export interface MappingChannel {
+  axis: 'x' | 'y' | 'z';
+  plane: RotationPlane;
+  gain: number;
+  clamp?: number;
+  smoothing?: number;
+}
+
+export interface PlaneMappingProfile {
+  id: string;
+  name: string;
+  spatial: MappingChannel[];
+  hyperspatial: MappingChannel[];
+}
+
+export const DEFAULT_PROFILE: PlaneMappingProfile = {
+  id: 'default-imu',
+  name: 'Default IMU',
+  spatial: [
+    { axis: 'x', plane: 'yz', gain: 1.0, smoothing: 0.1 },
+    { axis: 'y', plane: 'xz', gain: 0.95, smoothing: 0.1 },
+    { axis: 'z', plane: 'xy', gain: 0.9, smoothing: 0.1 }
+  ],
+  hyperspatial: [
+    { axis: 'x', plane: 'xw', gain: 0.35, smoothing: 0.2 },
+    { axis: 'y', plane: 'yw', gain: 0.35, smoothing: 0.2 },
+    { axis: 'z', plane: 'zw', gain: 0.35, smoothing: 0.2 }
+  ]
+};

--- a/src/ingestion/replayHarness.ts
+++ b/src/ingestion/replayHarness.ts
@@ -1,0 +1,24 @@
+import type { ImuPacket } from './imuMapper';
+import { Parserator, type ParseratorOptions } from './parserator';
+
+export interface ReplayOptions extends ParseratorOptions {
+  tickIntervalMs?: number;
+}
+
+export function replayDataset(packets: ImuPacket[], options: ReplayOptions = {}) {
+  const parserator = new Parserator(options);
+  const interval = options.tickIntervalMs ?? 16;
+
+  let index = 0;
+  function dispatchNext() {
+    if (index >= packets.length) return;
+    parserator.ingest(packets[index]);
+    index += 1;
+    if (index < packets.length) {
+      setTimeout(dispatchNext, interval);
+    }
+  }
+
+  dispatchNext();
+  return parserator;
+}

--- a/src/pipeline/contextScheduler.test.ts
+++ b/src/pipeline/contextScheduler.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { ContextScheduler } from './contextScheduler';
+
+describe('ContextScheduler', () => {
+  it('caps contexts and memory budgets', () => {
+    const scheduler = new ContextScheduler();
+    for (let i = 0; i < 25; i++) {
+      scheduler.registerContext({
+        id: `ctx-${i}`,
+        priority: i < 5 ? 'critical' : 'background',
+        memoryMB: 128
+      });
+    }
+    const snapshot = scheduler.getSnapshot();
+    expect(snapshot.active.length).toBeLessThanOrEqual(20);
+    expect(snapshot.rejected.length).toBeGreaterThan(0);
+    expect(snapshot.totalMemory).toBeLessThanOrEqual(4096);
+  });
+});

--- a/src/pipeline/contextScheduler.ts
+++ b/src/pipeline/contextScheduler.ts
@@ -1,0 +1,48 @@
+export type ContextPriority = 'critical' | 'interactive' | 'background';
+
+export interface ContextDescriptor {
+  id: string;
+  priority: ContextPriority;
+  memoryMB: number;
+}
+
+export interface SchedulerSnapshot {
+  active: ContextDescriptor[];
+  totalMemory: number;
+  rejected: ContextDescriptor[];
+}
+
+const PRIORITY_ORDER: ContextPriority[] = ['critical', 'interactive', 'background'];
+const MAX_CONTEXTS = 20;
+const MAX_MEMORY_MB = 4096;
+
+export class ContextScheduler {
+  private readonly contexts: ContextDescriptor[] = [];
+  private readonly rejected: ContextDescriptor[] = [];
+
+  registerContext(descriptor: ContextDescriptor) {
+    this.contexts.push(descriptor);
+    this.contexts.sort((a, b) => PRIORITY_ORDER.indexOf(a.priority) - PRIORITY_ORDER.indexOf(b.priority));
+    this.enforceBudgets();
+  }
+
+  getSnapshot(): SchedulerSnapshot {
+    return {
+      active: this.contexts.slice(),
+      totalMemory: this.contexts.reduce((sum, context) => sum + context.memoryMB, 0),
+      rejected: this.rejected.slice()
+    };
+  }
+
+  private enforceBudgets() {
+    while (this.contexts.length > MAX_CONTEXTS || this.totalMemory() > MAX_MEMORY_MB) {
+      const removed = this.contexts.pop();
+      if (!removed) break;
+      this.rejected.push(removed);
+    }
+  }
+
+  private totalMemory(): number {
+    return this.contexts.reduce((sum, context) => sum + context.memoryMB, 0);
+  }
+}

--- a/src/pipeline/datasetEncoder.ts
+++ b/src/pipeline/datasetEncoder.ts
@@ -1,0 +1,30 @@
+import type { FrameFormat, FramePayload } from './datasetExport';
+
+export async function encodeFramePayload(frame: FramePayload, format: FrameFormat): Promise<Blob> {
+  if (typeof OffscreenCanvas !== 'undefined') {
+    const canvas = new OffscreenCanvas(frame.width, frame.height);
+    const context = canvas.getContext('2d');
+    if (!context) throw new Error('Unable to allocate offscreen context');
+    const imageData = new ImageData(frame.pixels, frame.width, frame.height);
+    context.putImageData(imageData, 0, 0);
+    return canvas.convertToBlob({ type: format });
+  }
+
+  // Fallback: encode metadata + raw pixels as JSON for deterministic testing environments
+  const payload = {
+    format,
+    width: frame.width,
+    height: frame.height,
+    metadata: frame.metadata,
+    checksum: checksum(frame.pixels)
+  };
+  return new Blob([JSON.stringify(payload)], { type: 'application/json' });
+}
+
+export function checksum(pixels: Uint8ClampedArray): number {
+  let sum = 0;
+  for (let i = 0; i < pixels.length; i++) {
+    sum = (sum + pixels[i]) % 65536;
+  }
+  return sum;
+}

--- a/src/pipeline/datasetExport.test.ts
+++ b/src/pipeline/datasetExport.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { DatasetExportService, type EncodedFrame, type FrameFormat, type FramePayload } from './datasetExport';
+import { encodeFramePayload } from './datasetEncoder';
+
+type WorkerRequest = {
+  id: number;
+  format: FrameFormat;
+  frames: FramePayload[];
+};
+
+type WorkerResponse = {
+  id: number;
+  frames: EncodedFrame[];
+};
+
+describe('DatasetExportService', () => {
+  const nativeWorker = globalThis.Worker as typeof Worker | undefined;
+
+  afterEach(() => {
+    if (nativeWorker) {
+      globalThis.Worker = nativeWorker;
+    } else {
+      (globalThis as { Worker?: typeof Worker }).Worker = undefined;
+    }
+  });
+
+  it('encodes frames via JSON fallback when OffscreenCanvas is unavailable', async () => {
+    const service = new DatasetExportService();
+    expect(service.getMetrics()).toEqual({ pending: 0, totalEncoded: 0, lastFormat: null });
+    service.enqueue({
+      width: 2,
+      height: 2,
+      pixels: new Uint8ClampedArray([255, 0, 0, 255, 0, 255, 0, 255, 0, 0, 255, 255, 255, 255, 255, 255]),
+      metadata: {
+        timestamp: 1,
+        rotationAngles: [0, 0, 0, 0, 0, 0]
+      }
+    });
+    expect(service.getMetrics().pending).toBe(1);
+    const [frame] = await service.flush();
+    expect(frame.metadata.timestamp).toBe(1);
+    const text = await frame.blob.text();
+    expect(text).toContain('checksum');
+    expect(service.getMetrics()).toEqual({ pending: 0, totalEncoded: 1, lastFormat: 'image/png' });
+  });
+
+  it('dispatches frames to a worker when available', async () => {
+    const calls: WorkerRequest[] = [];
+
+    class MockWorker {
+      public onmessage: ((event: MessageEvent<WorkerResponse>) => void) | null = null;
+      public onerror: ((event: ErrorEvent) => void) | null = null;
+
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      constructor(_: URL, __?: WorkerOptions) {}
+
+      postMessage(data: WorkerRequest) {
+        calls.push(data);
+        Promise.resolve().then(async () => {
+          if (!this.onmessage) return;
+          const frames = await Promise.all(
+            data.frames.map(async frame => ({
+              blob: await encodeFramePayload(frame, data.format),
+              metadata: frame.metadata
+            }))
+          );
+          this.onmessage({ data: { id: data.id, frames } } as MessageEvent<WorkerResponse>);
+        });
+      }
+
+      terminate() {}
+    }
+
+    globalThis.Worker = MockWorker as unknown as typeof Worker;
+
+    const service = new DatasetExportService();
+    service.enqueue({
+      width: 1,
+      height: 1,
+      pixels: new Uint8ClampedArray([0, 0, 0, 255]),
+      metadata: { timestamp: 2, rotationAngles: [0, 0, 0, 0, 0, 0] }
+    });
+
+    const frames = await service.flush('image/webp');
+    expect(calls).toHaveLength(1);
+    expect(frames).toHaveLength(1);
+    expect(frames[0].metadata.timestamp).toBe(2);
+    expect(service.getMetrics()).toEqual({ pending: 0, totalEncoded: 1, lastFormat: 'image/webp' });
+  });
+});

--- a/src/pipeline/datasetExport.ts
+++ b/src/pipeline/datasetExport.ts
@@ -1,0 +1,164 @@
+import { encodeFramePayload } from './datasetEncoder';
+
+export type FrameFormat = 'image/png' | 'image/webp' | 'video/webm';
+
+export interface FrameMetadata {
+  timestamp: number;
+  rotationAngles: [number, number, number, number, number, number];
+}
+
+export interface FramePayload {
+  width: number;
+  height: number;
+  pixels: Uint8ClampedArray;
+  metadata: FrameMetadata;
+}
+
+export interface EncodedFrame {
+  blob: Blob;
+  metadata: FrameMetadata;
+}
+
+export interface DatasetExportMetrics {
+  pending: number;
+  totalEncoded: number;
+  lastFormat: FrameFormat | null;
+}
+
+interface WorkerRequest {
+  id: number;
+  format: FrameFormat;
+  frames: FramePayload[];
+}
+
+interface WorkerResponse {
+  id: number;
+  frames?: EncodedFrame[];
+  error?: { message: string };
+}
+
+type PendingJob = {
+  resolve: (frames: EncodedFrame[]) => void;
+  reject: (error: unknown) => void;
+};
+
+export class DatasetExportService {
+  private readonly queue: FramePayload[] = [];
+  private totalEncoded = 0;
+  private lastFormat: FrameFormat | null = null;
+  private worker: Worker | null = null;
+  private nextJobId = 1;
+  private readonly pendingJobs = new Map<number, PendingJob>();
+
+  constructor() {
+    if (typeof Worker !== 'undefined') {
+      try {
+        const worker = new Worker(new URL('./datasetExport.worker.ts', import.meta.url), {
+          type: 'module'
+        });
+        worker.onmessage = event => this.handleWorkerMessage(event.data as WorkerResponse);
+        worker.onerror = event => {
+          this.failAllPending(event);
+          this.disposeWorker();
+        };
+        this.worker = worker;
+      } catch (error) {
+        // Worker construction failed (e.g., unsupported environment). Fallback to inline encoding.
+        this.worker = null;
+      }
+    }
+  }
+
+  enqueue(frame: FramePayload) {
+    this.queue.push(frame);
+  }
+
+  async flush(format: FrameFormat = 'image/png'): Promise<EncodedFrame[]> {
+    const frames = this.queue.splice(0);
+    if (frames.length === 0) {
+      return [];
+    }
+
+    let results: EncodedFrame[];
+    if (this.worker) {
+      try {
+        results = await this.dispatchToWorker(frames, format);
+      } catch (error) {
+        // Fallback to inline encoding if the worker fails mid-flight.
+        this.disposeWorker();
+        results = await this.encodeInline(frames, format);
+      }
+    } else {
+      results = await this.encodeInline(frames, format);
+    }
+
+    if (results.length > 0) {
+      this.totalEncoded += results.length;
+      this.lastFormat = format;
+    }
+    return results;
+  }
+
+  getMetrics(): DatasetExportMetrics {
+    return {
+      pending: this.queue.length,
+      totalEncoded: this.totalEncoded,
+      lastFormat: this.lastFormat
+    };
+  }
+
+  private async encodeInline(frames: FramePayload[], format: FrameFormat): Promise<EncodedFrame[]> {
+    const results: EncodedFrame[] = [];
+    for (const frame of frames) {
+      results.push({
+        blob: await encodeFramePayload(frame, format),
+        metadata: frame.metadata
+      });
+    }
+    return results;
+  }
+
+  private dispatchToWorker(frames: FramePayload[], format: FrameFormat): Promise<EncodedFrame[]> {
+    if (!this.worker) {
+      return Promise.reject(new Error('Worker not available'));
+    }
+
+    const jobId = this.nextJobId++;
+    return new Promise<EncodedFrame[]>((resolve, reject) => {
+      this.pendingJobs.set(jobId, { resolve, reject });
+      try {
+        this.worker!.postMessage({ id: jobId, format, frames } satisfies WorkerRequest);
+      } catch (error) {
+        this.pendingJobs.delete(jobId);
+        reject(error);
+      }
+    });
+  }
+
+  private handleWorkerMessage(message: WorkerResponse) {
+    const job = this.pendingJobs.get(message.id);
+    if (!job) {
+      return;
+    }
+    this.pendingJobs.delete(message.id);
+    if (message.error) {
+      job.reject(new Error(message.error.message));
+      return;
+    }
+    job.resolve(message.frames ?? []);
+  }
+
+  private failAllPending(error: unknown) {
+    for (const [, job] of this.pendingJobs) {
+      job.reject(error);
+    }
+    this.pendingJobs.clear();
+  }
+
+  private disposeWorker() {
+    if (this.worker) {
+      this.worker.terminate?.();
+      this.worker = null;
+    }
+  }
+}

--- a/src/pipeline/datasetExport.worker.ts
+++ b/src/pipeline/datasetExport.worker.ts
@@ -1,0 +1,40 @@
+/// <reference lib="webworker" />
+
+import type { EncodedFrame, FrameFormat, FramePayload } from './datasetExport';
+import { encodeFramePayload } from './datasetEncoder';
+
+interface WorkerRequest {
+  id: number;
+  format: FrameFormat;
+  frames: FramePayload[];
+}
+
+interface WorkerResponse {
+  id: number;
+  frames: EncodedFrame[];
+}
+
+const ctx = self as unknown as DedicatedWorkerGlobalScope;
+
+ctx.addEventListener('message', async event => {
+  const data = event.data as WorkerRequest;
+  try {
+    const frames: EncodedFrame[] = [];
+    for (const frame of data.frames) {
+      frames.push({
+        blob: await encodeFramePayload(frame, data.format),
+        metadata: frame.metadata
+      });
+    }
+    ctx.postMessage({ id: data.id, frames } satisfies WorkerResponse);
+  } catch (error) {
+    ctx.postMessage({ id: data.id, error: serializeError(error) });
+  }
+});
+
+function serializeError(error: unknown): { message: string } {
+  if (error instanceof Error) {
+    return { message: error.message };
+  }
+  return { message: String(error) };
+}

--- a/src/pipeline/focusDirector.test.ts
+++ b/src/pipeline/focusDirector.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { FocusDirector } from './focusDirector';
+import { RotationBus } from './rotationBus';
+import type { GeometryDescriptor } from '../geometry/types';
+import type { GeometryId } from './geometryCatalog';
+
+class FakeGeometryController {
+  active: GeometryId | null = null;
+  constructor(private readonly geometries: GeometryDescriptor[]) {}
+  getAvailableGeometries() {
+    return this.geometries;
+  }
+  setActiveGeometry(id: GeometryId) {
+    this.active = id;
+  }
+}
+
+describe('FocusDirector', () => {
+  it('applies focus hints and falls back on timeout', () => {
+    const geometries = [{
+      id: 'tesseract',
+      name: 'Tesseract',
+      data: {
+        positions: new Float32Array(0),
+        indices: new Uint16Array(0),
+        drawMode: 0,
+        vertexStride: 4,
+        topology: { vertices: 16, edges: 32, faces: 24, cells: 8 }
+      }
+    } as GeometryDescriptor];
+    const controller = new FakeGeometryController(geometries);
+    const bus = new RotationBus();
+    const director = new FocusDirector(controller as any, bus, { timeoutMs: 10 });
+
+    director.ingestHint({ geometry: 'tesseract', rotationBias: { xy: 0.5 } });
+    bus.push({
+      xy: 0,
+      xz: 0,
+      yz: 0,
+      xw: 0,
+      yw: 0,
+      zw: 0,
+      timestamp: performance.now(),
+      confidence: 0.5
+    });
+    director.update(performance.now());
+    expect(controller.active).toBe('tesseract');
+
+    director.update(performance.now() + 20);
+    expect(controller.active).toBe('tesseract');
+  });
+});

--- a/src/pipeline/focusDirector.ts
+++ b/src/pipeline/focusDirector.ts
@@ -1,0 +1,86 @@
+import type { GeometryId } from './geometryCatalog';
+import type { GeometryController } from './geometryController';
+import type { RotationBus } from './rotationBus';
+import type { RotationAngles, RotationSnapshot } from '../core/rotationUniforms';
+
+export interface FocusHint {
+  geometry?: GeometryId;
+  rotationBias?: Partial<RotationAngles>;
+  confidenceBoost?: number;
+}
+
+export interface FocusDirectorOptions {
+  fallbackGeometry?: GeometryId;
+  timeoutMs?: number;
+}
+
+export class FocusDirector {
+  private lastHintAt = 0;
+  private readonly timeoutMs: number;
+  private readonly fallbackGeometry: GeometryId;
+  private rotationBias: Partial<RotationAngles> = {};
+  private confidenceBoost = 0;
+
+  constructor(
+    private readonly geometryController: GeometryController,
+    private readonly rotationBus: RotationBus,
+    options: FocusDirectorOptions = {}
+  ) {
+    this.timeoutMs = options.timeoutMs ?? 5000;
+    this.fallbackGeometry = options.fallbackGeometry ?? 'tesseract';
+  }
+
+  ingestHint(hint: FocusHint) {
+    this.lastHintAt = performance.now();
+    if (hint.geometry) {
+      this.geometryController.setActiveGeometry(hint.geometry);
+    }
+    if (hint.rotationBias) {
+      this.rotationBias = { ...hint.rotationBias };
+    }
+    if (typeof hint.confidenceBoost === 'number') {
+      this.confidenceBoost = hint.confidenceBoost;
+    }
+  }
+
+  update(snapshotTime = performance.now()) {
+    if (snapshotTime - this.lastHintAt > this.timeoutMs) {
+      this.geometryController.setActiveGeometry(this.fallbackGeometry);
+      this.rotationBias = {};
+      this.confidenceBoost = 0;
+      this.lastHintAt = snapshotTime;
+    }
+
+    const latest = this.rotationBus.getLatest({
+      xy: 0,
+      xz: 0,
+      yz: 0,
+      xw: 0,
+      yw: 0,
+      zw: 0,
+      timestamp: snapshotTime,
+      confidence: 1
+    });
+
+    let mutated = false;
+    const nextSnapshot: RotationSnapshot = { ...latest };
+    if (this.rotationBias) {
+      (Object.keys(this.rotationBias) as (keyof RotationAngles)[]).forEach(plane => {
+        const value = this.rotationBias[plane];
+        if (typeof value === 'number') {
+          nextSnapshot[plane] += value;
+          mutated = true;
+        }
+      });
+    }
+    if (this.confidenceBoost !== 0) {
+      nextSnapshot.confidence = Math.min(1, latest.confidence + this.confidenceBoost);
+      mutated = true;
+    }
+
+    if (mutated) {
+      nextSnapshot.timestamp = snapshotTime;
+      this.rotationBus.push({ ...nextSnapshot });
+    }
+  }
+}

--- a/src/pipeline/geometryCatalog.ts
+++ b/src/pipeline/geometryCatalog.ts
@@ -1,8 +1,9 @@
+import { SixHundredCellGeometry } from '../geometry/sixHundredCell';
 import { TesseractGeometry } from '../geometry/tesseract';
 import { TwentyFourCellGeometry } from '../geometry/twentyFourCell';
 import type { GeometryData, GeometryDescriptor } from '../geometry/types';
 
-export type GeometryId = 'tesseract' | 'twentyFourCell';
+export type GeometryId = 'tesseract' | 'twentyFourCell' | 'sixHundredCell';
 
 const CATALOG: Record<GeometryId, GeometryDescriptor> = {
   tesseract: {
@@ -14,6 +15,11 @@ const CATALOG: Record<GeometryId, GeometryDescriptor> = {
     id: 'twentyFourCell',
     name: '24-Cell',
     data: TwentyFourCellGeometry
+  },
+  sixHundredCell: {
+    id: 'sixHundredCell',
+    name: '600-Cell',
+    data: SixHundredCellGeometry
   }
 };
 

--- a/src/pipeline/geometryController.ts
+++ b/src/pipeline/geometryController.ts
@@ -1,0 +1,31 @@
+import type { GeometryDescriptor } from '../geometry/types';
+import { getGeometry, listGeometries, type GeometryId } from './geometryCatalog';
+import type { HypercubeCore } from '../core/hypercubeCore';
+
+export class GeometryController {
+  private readonly descriptors: GeometryDescriptor[];
+  private active: GeometryId | null = null;
+
+  constructor(private readonly core: HypercubeCore) {
+    this.descriptors = listGeometries();
+  }
+
+  getAvailableGeometries(): GeometryDescriptor[] {
+    return this.descriptors.slice();
+  }
+
+  getActiveGeometry(): GeometryId | null {
+    return this.active;
+  }
+
+  getDescriptor(id: GeometryId): GeometryDescriptor | undefined {
+    return this.descriptors.find(descriptor => descriptor.id === id);
+  }
+
+  setActiveGeometry(id: GeometryId) {
+    if (this.active === id) return;
+    const geometry = getGeometry(id);
+    this.core.setGeometry(geometry);
+    this.active = id;
+  }
+}

--- a/src/pipeline/haosBridge.test.ts
+++ b/src/pipeline/haosBridge.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it, vi } from 'vitest';
+import { HaosBridge } from './haosBridge';
+import { FocusDirector } from './focusDirector';
+import { RotationBus } from './rotationBus';
+
+const mockFocusDirector = {
+  ingestHint: vi.fn()
+} as unknown as FocusDirector;
+
+describe('HaosBridge', () => {
+  it('dispatches focus profile updates', () => {
+    const bridge = new HaosBridge(mockFocusDirector);
+    const response = bridge.handleRequest({ id: 1, method: 'setFocusProfile', params: { geometry: 'tesseract' } });
+    expect(response.result).toBe('ok');
+  });
+
+  it('returns method not found for unknown calls', () => {
+    const bridge = new HaosBridge(mockFocusDirector);
+    const response = bridge.handleRequest({ id: 2, method: 'unknown' });
+    expect(response.error?.code).toBe(-32601);
+  });
+});

--- a/src/pipeline/haosBridge.ts
+++ b/src/pipeline/haosBridge.ts
@@ -1,0 +1,40 @@
+import type { FocusDirector, FocusHint } from './focusDirector';
+
+export interface JsonRpcRequest {
+  id: string | number;
+  method: string;
+  params?: Record<string, unknown>;
+}
+
+export interface JsonRpcResponse {
+  id: string | number;
+  result?: unknown;
+  error?: { code: number; message: string };
+}
+
+export class HaosBridge {
+  constructor(private readonly focusDirector: FocusDirector) {}
+
+  handleRequest(request: JsonRpcRequest): JsonRpcResponse {
+    try {
+      switch (request.method) {
+        case 'setFocusProfile':
+          this.applyFocus(request.params as FocusHint);
+          return { id: request.id, result: 'ok' };
+        case 'queueRotationScript':
+          return { id: request.id, result: 'queued' };
+        case 'requestSnapshot':
+          return { id: request.id, result: { timestamp: performance.now() } };
+        default:
+          return { id: request.id, error: { code: -32601, message: 'Method not found' } };
+      }
+    } catch (error) {
+      return { id: request.id, error: { code: -32000, message: (error as Error).message } };
+    }
+  }
+
+  private applyFocus(params?: FocusHint) {
+    if (!params) return;
+    this.focusDirector.ingestHint(params);
+  }
+}

--- a/src/pipeline/projectionBridge.test.ts
+++ b/src/pipeline/projectionBridge.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { configureProjection } from './projectionBridge';
+import { vec4 } from 'gl-matrix';
+
+describe('ProjectionBridge', () => {
+  it('provides orthographic projection identity', () => {
+    const { project } = configureProjection('orthographic');
+    const input = vec4.fromValues(1, 2, 3, 4);
+    const result = project(input);
+    expect(Array.from(result)).toEqual([1, 2, 3]);
+  });
+
+  it('applies perspective depth scaling', () => {
+    const { project } = configureProjection('perspective', { distance: 5 });
+    const input = vec4.fromValues(1, 1, 1, 1);
+    const result = project(input);
+    expect(result[0]).toBeCloseTo(1 / 4);
+    expect(result[2]).toBeCloseTo(1 / 4);
+  });
+});

--- a/src/pipeline/projectionBridge.ts
+++ b/src/pipeline/projectionBridge.ts
@@ -1,0 +1,73 @@
+import type { vec4, vec3 } from 'gl-matrix';
+import { vec3 as Vec3 } from 'gl-matrix';
+
+export type ProjectionMode = 'perspective' | 'stereographic' | 'orthographic';
+
+export interface ProjectionParameters {
+  distance?: number;
+  focalLength?: number;
+  stereographicScale?: number;
+}
+
+export interface ProjectionConfig {
+  mode: ProjectionMode;
+  shaderSnippet: string;
+  project: (input: vec4) => vec3;
+}
+
+export function configureProjection(mode: ProjectionMode, parameters: ProjectionParameters = {}): ProjectionConfig {
+  switch (mode) {
+    case 'perspective':
+      return {
+        mode,
+        shaderSnippet: perspectiveSnippet(parameters.distance ?? 3.0),
+        project: vector => projectPerspective(vector, parameters.distance ?? 3.0)
+      };
+    case 'stereographic':
+      return {
+        mode,
+        shaderSnippet: stereographicSnippet(parameters.stereographicScale ?? 1.0),
+        project: vector => projectStereographic(vector, parameters.stereographicScale ?? 1.0)
+      };
+    case 'orthographic':
+    default:
+      return {
+        mode: 'orthographic',
+        shaderSnippet: orthographicSnippet(),
+        project: vector => Vec3.fromValues(vector[0], vector[1], vector[2])
+      };
+  }
+}
+
+function perspectiveSnippet(distance: number): string {
+  return `
+vec3 project4Dto3D(vec4 v) {
+  float depth = max(${distance.toFixed(3)} - v.w, 0.1);
+  return v.xyz / depth;
+}`.trim();
+}
+
+function stereographicSnippet(scale: number): string {
+  return `
+vec3 project4Dto3D(vec4 v) {
+  float denom = max(${scale.toFixed(3)} - v.w, 0.1);
+  return v.xyz / denom;
+}`.trim();
+}
+
+function orthographicSnippet(): string {
+  return `
+vec3 project4Dto3D(vec4 v) {
+  return v.xyz;
+}`.trim();
+}
+
+function projectPerspective(vector: vec4, distance: number): vec3 {
+  const depth = Math.max(distance - vector[3], 0.1);
+  return Vec3.fromValues(vector[0] / depth, vector[1] / depth, vector[2] / depth);
+}
+
+function projectStereographic(vector: vec4, scale: number): vec3 {
+  const denom = Math.max(scale - vector[3], 0.1);
+  return Vec3.fromValues(vector[0] / denom, vector[1] / denom, vector[2] / denom);
+}

--- a/src/pipeline/pspStream.test.ts
+++ b/src/pipeline/pspStream.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { LocalPspStream } from './pspStream';
+
+const mockBlob = new Blob(['test'], { type: 'text/plain' });
+
+describe('LocalPspStream', () => {
+  it('notifies subscribers of frames', async () => {
+    const stream = new LocalPspStream();
+    let received = 0;
+    stream.subscribe(frame => {
+      received += frame.metadata.timestamp;
+    });
+    stream.publish({
+      blob: mockBlob,
+      metadata: { timestamp: 2, rotationAngles: [0, 0, 0, 0, 0, 0] }
+    });
+    expect(received).toBe(2);
+  });
+});

--- a/src/pipeline/pspStream.ts
+++ b/src/pipeline/pspStream.ts
@@ -1,0 +1,25 @@
+import type { EncodedFrame } from './datasetExport';
+
+export interface PspSubscriber {
+  (frame: EncodedFrame): void;
+}
+
+export interface PspStream {
+  subscribe(listener: PspSubscriber): () => void;
+  publish(frame: EncodedFrame): void;
+}
+
+export class LocalPspStream implements PspStream {
+  private readonly listeners = new Set<PspSubscriber>();
+
+  subscribe(listener: PspSubscriber): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  publish(frame: EncodedFrame): void {
+    for (const listener of this.listeners) {
+      listener(frame);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- introduce a dedicated dataset export Web Worker and queue orchestration so frame encoding happens off the render thread
- extract shared encoding helpers to keep worker and fallback code paths byte-aligned and document the new session in the rebuild log
- extend dataset export tests with a worker-backed stub to validate metrics and worker dispatch behaviour

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5c4f267208329a9714855d5f3d9b1