### PR TITLE
Enable dual-quaternion rotations in HypercubeCore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+.dist
+/dist
+.vite
+.DS_Store

--- a/PPP_COMPLETE_SYSTEM_DOCUMENTATION.md
+++ b/PPP_COMPLETE_SYSTEM_DOCUMENTATION.md
@@ -398,6 +398,53 @@ Result: Single visual representation containing multiple data modalities
 - **Computer Vision**: Integration with OpenCV and modern deep learning frameworks
 - **Quantum Computing**: Specialized quantum syndrome processing and visualization tools
 
+### 5.3 HypercubeCore–CPE Rebuild Blueprint (Clean-Slate MVP)
+
+To ensure the six degrees of rotational freedom are implemented correctly and verifiably inside HypercubeCore, the MVP is restructured around a clean-room rebuild. Each stage defines required artefacts, measurable exit criteria, and explicit ownership of the SO(4) rotation chain so the resulting system can be trusted for live sensor embodiment and PSP generation.
+
+#### 5.3.1 Stage 0 – Foundational Scaffolding
+- **Repository Reset & Module Layout**: Establish a lean `/core` directory containing `HypercubeCore`, `RotationUniforms`, `GeometryCatalog`, `ProjectionBridge`, and `IOPipelines`. Remove legacy assets that obscure dependency flow.
+- **TypeScript First Build**: Stand up a TypeScript/WebGL2 toolchain with Vite (or equivalent) to guarantee typed uniforms, enum-guarded geometry IDs, and compile-time shader string validation.
+- **Validation Harness**: Create a headless Jest + gl-matrix test suite that can render offscreen via headless-gl, confirming shader compilation and rotation outputs before browser execution.
+
+#### 5.3.2 Stage 1 – Rotation Kernel & Uniform Contract
+- **Explicit SO(4) Struct**: Author `RotationUniforms.ts` exporting `RotationAngles` and `RotationDualQuaternion` interfaces, backed by a 6×float32 UBO slice plus optional dual-quaternion packing.
+- **Reference Implementation**: Implement `applySequentialRotations(vec4 v, RotationAngles angles)` using the documented plane order, alongside property-based tests comparing against `SO4` matrices from a Python oracle.
+- **Dual Quaternion Path**: Provide `composeDualQuaternion(angles)` with validation that sequential and dual-quaternion outputs match within ε < 1e-4 radians for randomized inputs.
+- **HypercubeCore Wiring**: Ensure the render loop reads only from the typed uniform buffer; mutation occurs exclusively via `RotationBus.pushSnapshot()` to avoid hidden state.
+
+#### 5.3.3 Stage 2 – Geometry Catalog & GPU Residency
+- **Geometry Definitions**: Rebuild tesseract, 24-cell, and 600-cell subsets as declarative JSON/TS assets (`vertices`, `edges`, `cells`) consumed by `GeometryCatalog`. Include unit tests verifying combinatorics (Euler characteristic = 0).
+- **GPU Upload Strategy**: Allocate static vertex buffers per geometry with instanced attributes for edges/cells. Design a `GeometryBinding` descriptor so rotations operate on GPU buffers without CPU reconstruction.
+- **Dynamic Selection Protocol**: Through `GeometryController.setActiveGeometry(id, rotationProfile)`, bind the appropriate buffers and configure projection hints (e.g., cell highlighting).
+
+#### 5.3.4 Stage 3 – Data Ingestion & Rotation Mapping
+- **Kerbelized Parserator v2**: Define a standalone ingestion microservice (Node + WebSocket) with pluggable preprocessing (`lowPassGyro`, `gravityIsolation`, `featureWindow`). Outputs normalized `RotationSnapshot` objects with timestamp and confidence.
+- **Implementation Note – Parserator MVP**: The current browser build ships with a Kerbelized Parserator core that packs the six SO(4) planes into a 128-channel UBO slice, applies configurable exponential smoothing, and enforces confidence floors before relaying frames to HypercubeCore. This module is already wired to the IMU WebSocket client, providing the deterministic upload loop required by the CPE.
+- **Sensor Coupling Profiles**: Implement `PlaneMappingProfile` records that map IMU channels to rotation planes with per-axis gain, clamp, and smoothing coefficients.
+- **Deterministic UBO Updates**: Within HypercubeCore, integrate a `UniformSyncQueue` that batches exactly one UBO upload per animation frame, guarded by dirty flags and measured via performance counters.
+- **Harmonic Rotation Loom**: Ship a default six-plane oscillator that weaves golden-ratio frequency ratios across spatial and hyperspatial planes so the Extrument always exposes a musically coherent SO(4) flow even before live sensors attach.
+- **Replay Harness**: Ship a CLI that replays recorded IMU datasets into the parserator, enabling regression tests without hardware.
+
+#### 5.3.5 Stage 4 – Projection Bridge & PSP Export
+- **ProjectionBridge API**: Consolidate perspective, stereographic, and orthographic projections behind `ProjectionBridge.configure({mode, parameters})`, returning shader snippets for injection.
+- **Multi-Context Budgeting**: Implement a scheduler that enforces the 20-context ceiling with priority tiers (live viewport, PSP export, ML tap). Include telemetry on GPU memory per context to maintain <4 GB usage.
+- **Uber-Shader Refactor**: Replace ad-hoc string concatenation with tagged-template shader builders ensuring injection points for geometry, projection, and color modules while sharing utility libraries (noise, palettes, rotation matrices).
+- **Dataset Export Service**: Provide a worker-thread pipeline that renders PSP frames to ImageBitmap, encodes to PNG/WebP/WebM with rotation metadata, and streams to disk or WebRTC for ML consumers.
+
+#### 5.3.6 Stage 5 – Metacognitive Feedback & HAOS Integration
+- **Inference Docking**: Define a `PspStream` interface emitting frame + metadata tuples consumable by ViT/CNN services via WebRTC DataChannels or gRPC-Web.
+- **Focus Feedback Loop**: Build `FocusDirector` which ingests ML guidance (`focusHints`, `rotationAdjustments`) and recalibrates parserator gain matrices or geometry selection in near-real time.
+- **HOAS Bridge Contract**: Document JSON-RPC methods (`setFocusProfile`, `queueRotationScript`, `requestSnapshot`) with audit logging so higher-level HAOS agents can orchestrate sessions.
+- **Safety & Recovery**: Implement watchdog timers and fallback geometries that activate when inference or ingestion fails, maintaining continuous though degraded visualization.
+
+#### 5.3.7 Stage 6 – Verification, Tooling & Delivery
+- **Continuous Integration**: Configure CI to run unit tests (rotation parity, geometry invariants), integration smoke tests (headless render diff), and lint/format checks on every commit.
+- **Performance Budget Tests**: Automate frame-time benchmarks with synthetic IMU streams to ensure ≥60 fps and <4 ms sensor-to-uniform latency on reference hardware (RTX 3060, M2 Pro).
+- **Developer Tooling**: Provide Storybook-like sandboxes for geometry inspection, rotation debug sliders, and shader playgrounds to accelerate research iteration.
+- **Documentation & Onboarding**: Author living docs describing API contracts, deployment topology (browser + Kubernetes workers), and troubleshooting guides, ensuring the rebuild is teachable and maintainable.
+
+
 ---
 
 ## Part VI: Technical Specifications & Performance Metrics

--- a/index.html
+++ b/index.html
@@ -1,0 +1,163 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>HypercubeCore – SO(4) MVP</title>
+    <style>
+      html, body {
+        margin: 0;
+        padding: 0;
+        height: 100%;
+        background: #050509;
+        color: #d7f9ff;
+        font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        overflow: hidden;
+      }
+      #app {
+        display: grid;
+        grid-template-columns: 320px 1fr;
+        height: 100%;
+      }
+      #control-panel {
+        background: rgba(12, 18, 32, 0.92);
+        border-right: 1px solid rgba(86, 180, 252, 0.25);
+        padding: 24px 20px;
+        display: flex;
+        flex-direction: column;
+        gap: 20px;
+        overflow-y: auto;
+      }
+      #control-panel h1 {
+        font-size: 1.25rem;
+        margin: 0;
+        color: #7fd2ff;
+      }
+      .control-group {
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+      }
+      .control-group label {
+        font-size: 0.85rem;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        color: #9edcff;
+      }
+      .control-group input[type="range"] {
+        width: 100%;
+      }
+      .meter-row {
+        display: grid;
+        grid-template-columns: 1fr minmax(0, 1fr) 50px;
+        align-items: center;
+        gap: 8px;
+        margin-bottom: 6px;
+      }
+      .meter-label {
+        font-size: 0.75rem;
+        letter-spacing: 0.06em;
+        color: rgba(159, 222, 255, 0.85);
+        text-transform: uppercase;
+      }
+      .meter-bar {
+        position: relative;
+        height: 6px;
+        background: rgba(68, 120, 180, 0.35);
+        border-radius: 999px;
+        overflow: hidden;
+      }
+      .meter-fill {
+        position: absolute;
+        top: 0;
+        left: 0;
+        bottom: 0;
+        width: 0%;
+        background: linear-gradient(90deg, #57d6ff, #9c6bff);
+        border-radius: 999px;
+        transition: width 0.18s ease-out;
+      }
+      .meter-value {
+        font-size: 0.75rem;
+        text-align: right;
+        color: rgba(214, 245, 255, 0.8);
+      }
+      .primary-button {
+        background: linear-gradient(120deg, rgba(87, 214, 255, 0.9), rgba(156, 107, 255, 0.9));
+        border: none;
+        color: #04131f;
+        padding: 12px 16px;
+        border-radius: 999px;
+        font-weight: 600;
+        letter-spacing: 0.08em;
+        cursor: pointer;
+        transition: transform 0.15s ease, box-shadow 0.15s ease;
+      }
+      .primary-button:hover {
+        transform: translateY(-1px);
+        box-shadow: 0 8px 24px rgba(93, 201, 255, 0.35);
+      }
+      .primary-button.active {
+        box-shadow: 0 0 0 2px rgba(95, 188, 255, 0.4);
+      }
+      .status-note {
+        font-size: 0.72rem;
+        color: rgba(180, 226, 255, 0.7);
+        margin: 0;
+      }
+      canvas {
+        width: 100%;
+        height: 100%;
+        display: block;
+      }
+      #status {
+        font-size: 0.75rem;
+        color: rgba(211, 246, 255, 0.7);
+      }
+    </style>
+  </head>
+  <body>
+    <div id="app">
+      <aside id="control-panel">
+        <header>
+          <h1>SO(4) Rotation Bus</h1>
+          <p id="status">Initializing…</p>
+        </header>
+        <section class="control-group">
+          <label for="geometry">Geometry</label>
+          <select id="geometry">
+            <option value="tesseract">Tesseract</option>
+            <option value="twentyFourCell">24-Cell</option>
+          </select>
+        </section>
+        <section class="control-group">
+          <label for="projectionMode">Projection Mode</label>
+          <select id="projectionMode">
+            <option value="perspective">Perspective</option>
+            <option value="stereographic">Stereographic</option>
+            <option value="orthographic">Orthographic</option>
+          </select>
+        </section>
+        <section id="rotation-controls"></section>
+        <section class="control-group">
+          <label for="projectionDepth" id="projectionDepthLabel">Projection Depth</label>
+          <input id="projectionDepth" type="range" min="1" max="8" step="0.1" value="3" />
+        </section>
+        <section class="control-group">
+          <label for="lineWidth">Line Width</label>
+          <input id="lineWidth" type="range" min="1" max="6" step="0.5" value="2" />
+        </section>
+        <section class="control-group">
+          <label>Rotation Harmonics</label>
+          <div id="style-indicators"></div>
+        </section>
+        <button id="audio-toggle" class="primary-button">Enable Sonic Weave</button>
+        <p id="audio-status" class="status-note">Audio engine idle. Click to invite the sonic loom.</p>
+        <button id="imu-toggle" class="primary-button">Connect IMU Stream</button>
+        <p id="imu-status" class="status-note">IMU stream idle. Click to connect.</p>
+      </aside>
+      <canvas id="gl-canvas"></canvas>
+    </div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1809 @@
+{
+  "name": "hypercube-core-webgl",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "hypercube-core-webgl",
+      "version": "0.1.0",
+      "dependencies": {
+        "gl-matrix": "^3.4.3"
+      },
+      "devDependencies": {
+        "@types/node": "^20.11.19",
+        "typescript": "^5.4.5",
+        "vite": "^5.2.0",
+        "vitest": "^1.3.1"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jest/schemas": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.27.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.52.2.tgz",
+      "integrity": "sha512-o3pcKzJgSGt4d74lSZ+OCnHwkKBeAbFDmbEm5gg70eA8VkyCuC/zV9TwBnmw6VjDlRdF4Pshfb+WE9E6XY1PoQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.52.2.tgz",
+      "integrity": "sha512-cqFSWO5tX2vhC9hJTK8WAiPIm4Q8q/cU8j2HQA0L3E1uXvBYbOZMhE2oFL8n2pKB5sOCHY6bBuHaRwG7TkfJyw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.52.2.tgz",
+      "integrity": "sha512-vngduywkkv8Fkh3wIZf5nFPXzWsNsVu1kvtLETWxTFf/5opZmflgVSeLgdHR56RQh71xhPhWoOkEBvbehwTlVA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.52.2.tgz",
+      "integrity": "sha512-h11KikYrUCYTrDj6h939hhMNlqU2fo/X4NB0OZcys3fya49o1hmFaczAiJWVAFgrM1NCP6RrO7lQKeVYSKBPSQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.52.2.tgz",
+      "integrity": "sha512-/eg4CI61ZUkLXxMHyVlmlGrSQZ34xqWlZNW43IAU4RmdzWEx0mQJ2mN/Cx4IHLVZFL6UBGAh+/GXhgvGb+nVxw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.52.2.tgz",
+      "integrity": "sha512-QOWgFH5X9+p+S1NAfOqc0z8qEpJIoUHf7OWjNUGOeW18Mx22lAUOiA9b6r2/vpzLdfxi/f+VWsYjUOMCcYh0Ng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.52.2.tgz",
+      "integrity": "sha512-kDWSPafToDd8LcBYd1t5jw7bD5Ojcu12S3uT372e5HKPzQt532vW+rGFFOaiR0opxePyUkHrwz8iWYEyH1IIQA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.52.2.tgz",
+      "integrity": "sha512-gKm7Mk9wCv6/rkzwCiUC4KnevYhlf8ztBrDRT9g/u//1fZLapSRc+eDZj2Eu2wpJ+0RzUKgtNijnVIB4ZxyL+w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.52.2.tgz",
+      "integrity": "sha512-66lA8vnj5mB/rtDNwPgrrKUOtCLVQypkyDa2gMfOefXK6rcZAxKLO9Fy3GkW8VkPnENv9hBkNOFfGLf6rNKGUg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.52.2.tgz",
+      "integrity": "sha512-s+OPucLNdJHvuZHuIz2WwncJ+SfWHFEmlC5nKMUgAelUeBUnlB4wt7rXWiyG4Zn07uY2Dd+SGyVa9oyLkVGOjA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.52.2.tgz",
+      "integrity": "sha512-8wTRM3+gVMDLLDdaT6tKmOE3lJyRy9NpJUS/ZRWmLCmOPIJhVyXwjBo+XbrrwtV33Em1/eCTd5TuGJm4+DmYjw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.52.2.tgz",
+      "integrity": "sha512-6yqEfgJ1anIeuP2P/zhtfBlDpXUb80t8DpbYwXQ3bQd95JMvUaqiX+fKqYqUwZXqdJDd8xdilNtsHM2N0cFm6A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.52.2.tgz",
+      "integrity": "sha512-sshYUiYVSEI2B6dp4jMncwxbrUqRdNApF2c3bhtLAU0qA8Lrri0p0NauOsTWh3yCCCDyBOjESHMExonp7Nzc0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.52.2.tgz",
+      "integrity": "sha512-duBLgd+3pqC4MMwBrKkFxaZerUxZcYApQVC5SdbF5/e/589GwVvlRUnyqMFbM8iUSb1BaoX/3fRL7hB9m2Pj8Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.52.2.tgz",
+      "integrity": "sha512-tzhYJJidDUVGMgVyE+PmxENPHlvvqm1KILjjZhB8/xHYqAGeizh3GBGf9u6WdJpZrz1aCpIIHG0LgJgH9rVjHQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.52.2.tgz",
+      "integrity": "sha512-opH8GSUuVcCSSyHHcl5hELrmnk4waZoVpgn/4FDao9iyE4WpQhyWJ5ryl5M3ocp4qkRuHfyXnGqg8M9oKCEKRA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.52.2.tgz",
+      "integrity": "sha512-LSeBHnGli1pPKVJ79ZVJgeZWWZXkEe/5o8kcn23M8eMKCUANejchJbF/JqzM4RRjOJfNRhKJk8FuqL1GKjF5oQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.52.2.tgz",
+      "integrity": "sha512-uPj7MQ6/s+/GOpolavm6BPo+6CbhbKYyZHUDvZ/SmJM7pfDBgdGisFX3bY/CBDMg2ZO4utfhlApkSfZ92yXw7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.52.2.tgz",
+      "integrity": "sha512-Z9MUCrSgIaUeeHAiNkm3cQyst2UhzjPraR3gYYfOjAuZI7tcFRTOD+4cHLPoS/3qinchth+V56vtqz1Tv+6KPA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.52.2.tgz",
+      "integrity": "sha512-+GnYBmpjldD3XQd+HMejo+0gJGwYIOfFeoBQv32xF/RUIvccUz20/V6Otdv+57NE70D5pa8W/jVGDoGq0oON4A==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.52.2.tgz",
+      "integrity": "sha512-ApXFKluSB6kDQkAqZOKXBjiaqdF1BlKi+/eqnYe9Ee7U2K3pUDKsIyr8EYm/QDHTJIM+4X+lI0gJc3TTRhd+dA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.52.2.tgz",
+      "integrity": "sha512-ARz+Bs8kY6FtitYM96PqPEVvPXqEZmPZsSkXvyX19YzDqkCaIlhCieLLMI5hxO9SRZ2XtCtm8wxhy0iJ2jxNfw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.27.8",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
+      "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.17.tgz",
+      "integrity": "sha512-gfehUI8N1z92kygssiuWvLiwcbOB3IRktR6hTDgJlXMYh5OvkPSRmgfoBUmfZt+vhwJtX7v1Yw4KvvAf7c5QKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-1.6.1.tgz",
+      "integrity": "sha512-jXL+9+ZNIJKruofqXuuTClf44eSpcHlgj3CiuNihUF3Ioujtmc0zIa3UJOW5RjDK1YLBJZnWBlPuqhYycLioog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "1.6.1",
+        "@vitest/utils": "1.6.1",
+        "chai": "^4.3.10"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-1.6.1.tgz",
+      "integrity": "sha512-3nSnYXkVkf3mXFfE7vVyPmi3Sazhb/2cfZGGs0JRzFsPFvAMBEcrweV1V1GsrstdXeKCTXlJbvnQwGWgEIHmOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "1.6.1",
+        "p-limit": "^5.0.0",
+        "pathe": "^1.1.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-1.6.1.tgz",
+      "integrity": "sha512-WvidQuWAzU2p95u8GAKlRMqMyN1yOJkGHnx3M1PL9Raf7AQ1kwLKg04ADlCa3+OXUZE7BceOhVZiuWAbzCKcUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "magic-string": "^0.30.5",
+        "pathe": "^1.1.1",
+        "pretty-format": "^29.7.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-1.6.1.tgz",
+      "integrity": "sha512-MGcMmpGkZebsMZhbQKkAf9CX5zGvjkBTqf8Zx3ApYWXr3wG+QvEu2eXWfnIIWYSJExIp4V9FCKDEeygzkYrXMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^2.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-1.6.1.tgz",
+      "integrity": "sha512-jOrrUvXM4Av9ZWiG1EajNto0u96kWAhJ1LmPmJhXXQx/32MecEKd10pOLYgS2BQx1TgkGhloPU1ArDW2vvaY6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "diff-sequences": "^29.6.3",
+        "estree-walker": "^3.0.3",
+        "loupe": "^2.3.7",
+        "pretty-format": "^29.7.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.5.0.tgz",
+      "integrity": "sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.3",
+        "deep-eql": "^4.1.3",
+        "get-func-name": "^2.0.2",
+        "loupe": "^2.3.6",
+        "pathval": "^1.1.1",
+        "type-detect": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
+      "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-func-name": "^2.0.2"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz",
+      "integrity": "sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-detect": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/diff-sequences": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/execa": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+      "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^8.0.1",
+        "human-signals": "^5.0.0",
+        "is-stream": "^3.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^5.1.0",
+        "onetime": "^6.0.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.17"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-func-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
+      "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+      "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/gl-matrix": {
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.4.4.tgz",
+      "integrity": "sha512-latSnyDNt/8zYUB6VIJ6PCh2jBjJX6gnDsoCZ7LyW7GkqrD51EWwa9qCoGixj8YqBtETQK/xY7OmpTF8xz1DdQ==",
+      "license": "MIT"
+    },
+    "node_modules/human-signals": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+      "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.17.0"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/local-pkg": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-0.5.1.tgz",
+      "integrity": "sha512-9rrA30MRRP3gBD3HTGnC6cDFpaE1kVDWxWgqWJUN0RvDNAo+Nz/9GxB+nHOH0ifbVFy0hSA1V6vFDvnx54lTEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mlly": "^1.7.3",
+        "pkg-types": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
+      "integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-func-name": "^2.0.1"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.19",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.19.tgz",
+      "integrity": "sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mimic-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mlly": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.0.tgz",
+      "integrity": "sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "pathe": "^2.0.3",
+        "pkg-types": "^1.3.1",
+        "ufo": "^1.6.1"
+      }
+    },
+    "node_modules/mlly/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+      "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-run-path/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-5.0.0.tgz",
+      "integrity": "sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/pkg-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.1"
+      }
+    },
+    "node_modules/pkg-types/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rollup": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.52.2.tgz",
+      "integrity": "sha512-I25/2QgoROE1vYV+NQ1En9T9UFB9Cmfm2CJ83zZOlaDpvz29wGQSZXWKw7MiNXau7wYgB/T9fVIdIuEQ+KbiiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.52.2",
+        "@rollup/rollup-android-arm64": "4.52.2",
+        "@rollup/rollup-darwin-arm64": "4.52.2",
+        "@rollup/rollup-darwin-x64": "4.52.2",
+        "@rollup/rollup-freebsd-arm64": "4.52.2",
+        "@rollup/rollup-freebsd-x64": "4.52.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.52.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.52.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.52.2",
+        "@rollup/rollup-linux-arm64-musl": "4.52.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.52.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.52.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.52.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.52.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.52.2",
+        "@rollup/rollup-linux-x64-gnu": "4.52.2",
+        "@rollup/rollup-linux-x64-musl": "4.52.2",
+        "@rollup/rollup-openharmony-arm64": "4.52.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.52.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.52.2",
+        "@rollup/rollup-win32-x64-gnu": "4.52.2",
+        "@rollup/rollup-win32-x64-msvc": "4.52.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.9.0.tgz",
+      "integrity": "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-final-newline": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-2.1.1.tgz",
+      "integrity": "sha512-631UJ6O00eNGfMiWG78ck80dfBab8X6IVFB51jZK5Icd7XAs60Z5y7QdSd/wGIklnWvRbUNloVzhOKKmutxQ6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-0.8.4.tgz",
+      "integrity": "sha512-i11VH5gS6IFeLY3gMBQ00/MmLncVP7JLXOw1vlgkytLmJK7QnEr7NXf0LBdxfmNPAeyetukOk0bOYrJrFGjYJQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-2.2.1.tgz",
+      "integrity": "sha512-KYad6Vy5VDWV4GH3fjpseMQ/XU2BhIYP7Vzd0LG44qRWm/Yt2WCOTicFdvmgo6gWaqooMQCawTtILVQJupKu7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/type-detect": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
+      "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/ufo": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.1.tgz",
+      "integrity": "sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "5.4.20",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.20.tgz",
+      "integrity": "sha512-j3lYzGC3P+B5Yfy/pfKNgVEg4+UtcIJcVRt2cDjIOmhLourAqPqf8P7acgxeiSgUB7E3p2P8/3gNIgDLpwzs4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-1.6.1.tgz",
+      "integrity": "sha512-YAXkfvGtuTzwWbDSACdJSg4A4DZiAqckWe90Zapc/sEX3XvHcw1NdurM/6od8J207tSDqNbSsgdCacBgvJKFuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.4",
+        "pathe": "^1.1.1",
+        "picocolors": "^1.0.0",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-1.6.1.tgz",
+      "integrity": "sha512-Ljb1cnSJSivGN0LqXd/zmDbWEM0RNNg2t1QW/XUhYl/qPqyu7CsqeWtqQXHVaJsecLPuDoak2oJcZN2QoRIOag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "1.6.1",
+        "@vitest/runner": "1.6.1",
+        "@vitest/snapshot": "1.6.1",
+        "@vitest/spy": "1.6.1",
+        "@vitest/utils": "1.6.1",
+        "acorn-walk": "^8.3.2",
+        "chai": "^4.3.10",
+        "debug": "^4.3.4",
+        "execa": "^8.0.1",
+        "local-pkg": "^0.5.0",
+        "magic-string": "^0.30.5",
+        "pathe": "^1.1.1",
+        "picocolors": "^1.0.0",
+        "std-env": "^3.5.0",
+        "strip-literal": "^2.0.0",
+        "tinybench": "^2.5.1",
+        "tinypool": "^0.8.3",
+        "vite": "^5.0.0",
+        "vite-node": "1.6.1",
+        "why-is-node-running": "^2.2.2"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "1.6.1",
+        "@vitest/ui": "1.6.1",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.1.tgz",
+      "integrity": "sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "hypercube-core-webgl",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "test": "vitest"
+  },
+  "dependencies": {
+    "gl-matrix": "^3.4.3"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.19",
+    "typescript": "^5.4.5",
+    "vite": "^5.2.0",
+    "vitest": "^1.3.1"
+  }
+}

--- a/src/audio/extrumentSynth.ts
+++ b/src/audio/extrumentSynth.ts
@@ -1,0 +1,133 @@
+import type { RotationDynamics } from '../core/styleUniforms';
+import type { RotationSnapshot } from '../core/rotationUniforms';
+
+const MIN_GAIN = 0.02;
+const MAX_GAIN = 0.55;
+
+function getAudioContextConstructor(): typeof AudioContext | null {
+  const ctor = (window.AudioContext || (window as typeof window & { webkitAudioContext?: typeof AudioContext }).webkitAudioContext);
+  return ctor ?? null;
+}
+
+export class ExtrumentSynth {
+  private context: AudioContext | null = null;
+  private master: GainNode | null = null;
+  private filter: BiquadFilterNode | null = null;
+  private carriers: OscillatorNode[] = [];
+  private lfo: OscillatorNode | null = null;
+  private lfoGain: GainNode | null = null;
+  private active = false;
+
+  get isActive(): boolean {
+    return this.active;
+  }
+
+  async enable(): Promise<void> {
+    if (this.active) return;
+    const Ctor = getAudioContextConstructor();
+    if (!Ctor) {
+      throw new Error('Web Audio API is not supported in this environment.');
+    }
+    const context = new Ctor();
+    await context.resume();
+
+    const master = context.createGain();
+    master.gain.value = 0;
+    master.connect(context.destination);
+
+    const filter = context.createBiquadFilter();
+    filter.type = 'bandpass';
+    filter.Q.value = 6;
+    filter.frequency.value = 400;
+    filter.connect(master);
+
+    const carrierFrequencies = [110, 220, 330];
+    this.carriers = carrierFrequencies.map((base, index) => {
+      const osc = context.createOscillator();
+      osc.type = index === 0 ? 'sine' : index === 1 ? 'triangle' : 'sawtooth';
+      osc.frequency.value = base;
+      osc.connect(filter);
+      osc.start();
+      return osc;
+    });
+
+    const lfo = context.createOscillator();
+    lfo.type = 'sine';
+    lfo.frequency.value = 0.3;
+    const lfoGain = context.createGain();
+    lfoGain.gain.value = 40;
+    lfo.connect(lfoGain);
+    lfoGain.connect(filter.detune);
+    lfo.start();
+
+    this.context = context;
+    this.master = master;
+    this.filter = filter;
+    this.lfo = lfo;
+    this.lfoGain = lfoGain;
+    this.active = true;
+  }
+
+  async disable(): Promise<void> {
+    if (!this.active) return;
+    this.active = false;
+
+    if (this.context) {
+      const stopAt = this.context.currentTime + 0.1;
+      if (this.master) {
+        this.master.gain.setTargetAtTime(0, this.context.currentTime, 0.05);
+      }
+      for (const osc of this.carriers) {
+        osc.stop(stopAt);
+      }
+      if (this.lfo) {
+        this.lfo.stop(stopAt);
+      }
+      setTimeout(() => {
+        this.context?.close();
+      }, 150);
+    }
+
+    this.context = null;
+    this.master = null;
+    this.filter = null;
+    this.carriers = [];
+    this.lfo = null;
+    this.lfoGain = null;
+  }
+
+  update(snapshot: RotationSnapshot, dynamics: RotationDynamics) {
+    if (!this.active || !this.context || !this.master || !this.filter) {
+      return;
+    }
+
+    const { currentTime } = this.context;
+    const targetGain = MIN_GAIN + (MAX_GAIN - MIN_GAIN) * dynamics.energy * snapshot.confidence;
+    this.master.gain.setTargetAtTime(targetGain, currentTime, 0.08);
+
+    const spatialFundamental = 140 + 420 * dynamics.spatial;
+    const hyperFundamental = 160 + 560 * dynamics.hyperspatial;
+    const harmonicBend = 0.9 + dynamics.harmonic * 0.8;
+
+    if (this.carriers[0]) {
+      this.carriers[0].frequency.setTargetAtTime(spatialFundamental, currentTime, 0.05);
+    }
+    if (this.carriers[1]) {
+      const beat = spatialFundamental * harmonicBend;
+      this.carriers[1].frequency.setTargetAtTime(beat, currentTime, 0.08);
+    }
+    if (this.carriers[2]) {
+      const hyper = hyperFundamental * (1.1 + dynamics.chaos * 0.6);
+      this.carriers[2].frequency.setTargetAtTime(hyper, currentTime, 0.12);
+    }
+
+    const filterFrequency = 250 + 1850 * dynamics.harmonic;
+    this.filter.frequency.setTargetAtTime(filterFrequency, currentTime, 0.1);
+    this.filter.Q.setTargetAtTime(4 + dynamics.chaos * 8, currentTime, 0.1);
+
+    if (this.lfoGain) {
+      const detuneDepth = 20 + dynamics.chaos * 120;
+      this.lfoGain.gain.setTargetAtTime(detuneDepth, currentTime, 0.2);
+    }
+  }
+}

--- a/src/core/hypercubeCore.ts
+++ b/src/core/hypercubeCore.ts
@@ -1,0 +1,557 @@
+import {
+  RotationUniformBuffer,
+  ZERO_ROTATION,
+  type RotationAngles
+} from './rotationUniforms';
+import { StyleUniformBuffer, type RotationDynamics, ZERO_DYNAMICS } from './styleUniforms';
+import {
+  buildProjectionUniforms,
+  DEFAULT_PROJECTION_PARAMETERS,
+  projectionModeToIndex,
+  type ProjectionMode,
+  type ProjectionParameters,
+  updateProjectionParameter
+} from './projectionBridge';
+import type { GeometryData } from '../geometry/types';
+
+export type RotationMode = 'sequential' | 'dual-quaternion';
+
+export interface HypercubeCoreOptions {
+  projectionDepth?: number;
+  lineWidth?: number;
+  projectionMode?: ProjectionMode;
+  projectionParameters?: Partial<ProjectionParameters>;
+  rotationMode?: RotationMode;
+}
+
+export class HypercubeCore {
+  private readonly gl: WebGL2RenderingContext;
+  private readonly rotationBuffer: RotationUniformBuffer;
+  private readonly styleBuffer: StyleUniformBuffer;
+  private program: WebGLProgram;
+  private vao: WebGLVertexArrayObject | null = null;
+  private indexCount = 0;
+  private projectionDepth = 3;
+  private projectionMode: ProjectionMode = 'perspective';
+  private projectionParameters: ProjectionParameters = { ...DEFAULT_PROJECTION_PARAMETERS };
+  private readonly projectionUniformData = new Float32Array(4);
+  private projectionUniformMode = 0;
+  private projectionParamsDirty = true;
+  private projectionUploadDirty = true;
+  private lineWidth = 1.5;
+  private dynamicLineScale = 1;
+  private lastTimestamp = 0;
+  private animationHandle: number | null = null;
+  private readonly stagedRotation: RotationAngles = { ...ZERO_ROTATION };
+  private rotationDirty = true;
+  private readonly stagedDynamics: RotationDynamics = { ...ZERO_DYNAMICS };
+  private dynamicsDirty = true;
+  private rotationMode: RotationMode = 'sequential';
+  private rotationModeDirty = true;
+
+  private uniforms!: {
+    projectionDepth: WebGLUniformLocation;
+    lineWidth: WebGLUniformLocation;
+    time: WebGLUniformLocation;
+    projectionMode: WebGLUniformLocation;
+    projectionParams: WebGLUniformLocation;
+    rotationMode: WebGLUniformLocation;
+  };
+
+  constructor(private readonly canvas: HTMLCanvasElement, options: HypercubeCoreOptions = {}) {
+    const gl = canvas.getContext('webgl2');
+    if (!gl) {
+      throw new Error('WebGL2 is required for HypercubeCore.');
+    }
+    this.gl = gl;
+    this.rotationBuffer = new RotationUniformBuffer(gl);
+    this.styleBuffer = new StyleUniformBuffer(gl);
+    this.projectionDepth = options.projectionDepth ?? this.projectionDepth;
+    this.projectionMode = options.projectionMode ?? this.projectionMode;
+    this.projectionParameters = {
+      ...DEFAULT_PROJECTION_PARAMETERS,
+      depth: this.projectionDepth,
+      ...(options.projectionParameters ?? {})
+    };
+    this.projectionUniformMode = projectionModeToIndex(this.projectionMode);
+    this.lineWidth = options.lineWidth ?? this.lineWidth;
+    this.rotationMode = options.rotationMode ?? this.rotationMode;
+    this.program = this.createProgram();
+    this.rotationBuffer.bind(this.program);
+    this.styleBuffer.bind(this.program);
+    this.rotationBuffer.update(ZERO_ROTATION);
+    this.styleBuffer.update(ZERO_DYNAMICS);
+    this.uniforms = this.getUniformLocations();
+    this.configureContext();
+    this.projectionParamsDirty = true;
+    this.projectionUploadDirty = true;
+    this.resize();
+    window.addEventListener('resize', () => this.resize());
+  }
+
+  setProjectionDepth(depth: number) {
+    this.projectionDepth = depth;
+    this.projectionParameters = {
+      ...this.projectionParameters,
+      depth: Math.max(depth, this.projectionParameters.epsilon)
+    };
+    this.projectionParamsDirty = true;
+    this.projectionUploadDirty = true;
+  }
+
+  setLineWidth(width: number) {
+    this.lineWidth = width;
+  }
+
+  setProjectionMode(mode: ProjectionMode) {
+    if (this.projectionMode === mode) return;
+    this.projectionMode = mode;
+    this.projectionUniformMode = projectionModeToIndex(mode);
+    this.projectionParamsDirty = true;
+    this.projectionUploadDirty = true;
+  }
+
+  setProjectionControl(value: number) {
+    this.projectionParameters = updateProjectionParameter(
+      this.projectionMode,
+      this.projectionParameters,
+      value
+    );
+    this.projectionParamsDirty = true;
+    this.projectionUploadDirty = true;
+  }
+
+  configureProjection(parameters: Partial<ProjectionParameters>) {
+    this.projectionParameters = {
+      ...this.projectionParameters,
+      ...parameters
+    };
+    this.projectionParamsDirty = true;
+    this.projectionUploadDirty = true;
+  }
+
+  setGeometry(geometry: GeometryData) {
+    const { gl } = this;
+    if (!this.vao) {
+      this.vao = gl.createVertexArray();
+    }
+    gl.bindVertexArray(this.vao);
+
+    const positionBuffer = gl.createBuffer();
+    if (!positionBuffer) {
+      throw new Error('Failed to create vertex buffer');
+    }
+    gl.bindBuffer(gl.ARRAY_BUFFER, positionBuffer);
+    gl.bufferData(gl.ARRAY_BUFFER, geometry.positions, gl.STATIC_DRAW);
+    gl.enableVertexAttribArray(0);
+    gl.vertexAttribPointer(0, geometry.vertexStride, gl.FLOAT, false, 0, 0);
+
+    const indexBuffer = gl.createBuffer();
+    if (!indexBuffer) {
+      throw new Error('Failed to create index buffer');
+    }
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, indexBuffer);
+    gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, geometry.indices, gl.STATIC_DRAW);
+
+    this.indexCount = geometry.indices.length;
+    gl.bindVertexArray(null);
+  }
+
+  updateRotation(angles: RotationAngles) {
+    copyRotationAngles(this.stagedRotation, angles);
+    this.rotationDirty = true;
+  }
+
+  updateDynamics(dynamics: RotationDynamics) {
+    this.dynamicLineScale = dynamics.thickness;
+    copyDynamics(this.stagedDynamics, dynamics);
+    this.dynamicsDirty = true;
+  }
+
+  setRotationMode(mode: RotationMode) {
+    if (this.rotationMode === mode) return;
+    this.rotationMode = mode;
+    this.rotationModeDirty = true;
+  }
+
+  start() {
+    if (this.animationHandle !== null) return;
+    const loop = (timestamp: number) => {
+      if (this.lastTimestamp === 0) {
+        this.lastTimestamp = timestamp;
+      }
+      const dt = (timestamp - this.lastTimestamp) / 1000;
+      this.lastTimestamp = timestamp;
+      this.render(timestamp * 0.001, dt);
+      this.animationHandle = requestAnimationFrame(loop);
+    };
+    this.animationHandle = requestAnimationFrame(loop);
+  }
+
+  stop() {
+    if (this.animationHandle !== null) {
+      cancelAnimationFrame(this.animationHandle);
+      this.animationHandle = null;
+    }
+  }
+
+  private render(time: number, deltaTime: number) {
+    const { gl } = this;
+    gl.viewport(0, 0, gl.canvas.width, gl.canvas.height);
+    gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
+
+    gl.useProgram(this.program);
+    gl.bindVertexArray(this.vao);
+
+    this.flushUniformQueues();
+    this.syncProjectionUniforms();
+
+    gl.uniform1f(this.uniforms.projectionDepth, this.projectionDepth);
+    const modulatedLineWidth = this.lineWidth * this.dynamicLineScale;
+    gl.uniform1f(this.uniforms.lineWidth, modulatedLineWidth);
+    gl.uniform1f(this.uniforms.time, time);
+    if (this.projectionUploadDirty) {
+      gl.uniform1i(this.uniforms.projectionMode, this.projectionUniformMode);
+      gl.uniform4fv(this.uniforms.projectionParams, this.projectionUniformData);
+      this.projectionUploadDirty = false;
+    }
+    if (this.rotationModeDirty) {
+      gl.uniform1i(this.uniforms.rotationMode, this.rotationMode === 'dual-quaternion' ? 1 : 0);
+      this.rotationModeDirty = false;
+    }
+    gl.lineWidth(Math.max(1, Math.min(modulatedLineWidth, 8)));
+
+    gl.drawElements(gl.LINES, this.indexCount, gl.UNSIGNED_SHORT, 0);
+    gl.bindVertexArray(null);
+  }
+
+  private flushUniformQueues() {
+    if (this.rotationDirty) {
+      this.rotationBuffer.update(this.stagedRotation);
+      this.rotationDirty = false;
+    }
+    if (this.dynamicsDirty) {
+      this.styleBuffer.update(this.stagedDynamics);
+      this.dynamicsDirty = false;
+    }
+  }
+
+  private syncProjectionUniforms() {
+    if (this.projectionParamsDirty) {
+      const uniforms = buildProjectionUniforms(
+        this.projectionMode,
+        this.projectionParameters,
+        this.projectionUniformData
+      );
+      this.projectionUniformMode = uniforms.mode;
+      this.projectionParamsDirty = false;
+      this.projectionUploadDirty = true;
+    }
+  }
+
+  private configureContext() {
+    const { gl } = this;
+    gl.clearColor(0.01, 0.01, 0.04, 1);
+    gl.enable(gl.BLEND);
+    gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);
+    gl.enable(gl.DEPTH_TEST);
+    gl.lineWidth(this.lineWidth);
+  }
+
+  private resize() {
+    const { canvas } = this.gl;
+    const dpr = window.devicePixelRatio || 1;
+    const displayWidth = Math.floor(this.canvas.clientWidth * dpr);
+    const displayHeight = Math.floor(this.canvas.clientHeight * dpr);
+    if (canvas.width !== displayWidth || canvas.height !== displayHeight) {
+      canvas.width = displayWidth;
+      canvas.height = displayHeight;
+    }
+  }
+
+  private createProgram(): WebGLProgram {
+    const vertexSource = `#version 300 es\n${VERTEX_SHADER}`;
+    const fragmentSource = `#version 300 es\n${FRAGMENT_SHADER}`;
+    const vertexShader = this.compileShader(vertexSource, this.gl.VERTEX_SHADER);
+    const fragmentShader = this.compileShader(fragmentSource, this.gl.FRAGMENT_SHADER);
+
+    const program = this.gl.createProgram();
+    if (!program) {
+      throw new Error('Unable to create shader program');
+    }
+    this.gl.attachShader(program, vertexShader);
+    this.gl.attachShader(program, fragmentShader);
+    this.gl.linkProgram(program);
+    if (!this.gl.getProgramParameter(program, this.gl.LINK_STATUS)) {
+      throw new Error(`Program link failed: ${this.gl.getProgramInfoLog(program)}`);
+    }
+    return program;
+  }
+
+  private compileShader(source: string, type: number): WebGLShader {
+    const shader = this.gl.createShader(type);
+    if (!shader) {
+      throw new Error('Unable to allocate shader');
+    }
+    this.gl.shaderSource(shader, source);
+    this.gl.compileShader(shader);
+    if (!this.gl.getShaderParameter(shader, this.gl.COMPILE_STATUS)) {
+      throw new Error(`Shader compile error: ${this.gl.getShaderInfoLog(shader)}\n${source}`);
+    }
+    return shader;
+  }
+
+  private getUniformLocations() {
+    const projectionDepth = this.gl.getUniformLocation(this.program, 'u_projectionDepth');
+    const lineWidth = this.gl.getUniformLocation(this.program, 'u_lineWidth');
+    const time = this.gl.getUniformLocation(this.program, 'u_time');
+    const projectionMode = this.gl.getUniformLocation(this.program, 'u_projectionMode');
+    const projectionParams = this.gl.getUniformLocation(this.program, 'u_projectionParams');
+    const rotationMode = this.gl.getUniformLocation(this.program, 'u_rotationMode');
+    if (!projectionDepth || !lineWidth || !time || !projectionMode || !projectionParams || !rotationMode) {
+      throw new Error('Failed to resolve uniform locations');
+    }
+    return { projectionDepth, lineWidth, time, projectionMode, projectionParams, rotationMode };
+  }
+}
+
+function copyRotationAngles(target: RotationAngles, source: RotationAngles) {
+  target.xy = source.xy;
+  target.xz = source.xz;
+  target.yz = source.yz;
+  target.xw = source.xw;
+  target.yw = source.yw;
+  target.zw = source.zw;
+}
+
+function copyDynamics(target: RotationDynamics, source: RotationDynamics) {
+  target.energy = source.energy;
+  target.spatial = source.spatial;
+  target.hyperspatial = source.hyperspatial;
+  target.harmonic = source.harmonic;
+  target.saturation = source.saturation;
+  target.brightness = source.brightness;
+  target.thickness = source.thickness;
+  target.chaos = source.chaos;
+}
+
+const VERTEX_SHADER = `
+precision highp float;
+layout(location = 0) in vec4 a_position4d;
+
+layout(std140) uniform RotationUniforms {
+  vec4 spatial;    // xy, xz, yz, padding
+  vec4 hyperspatial; // xw, yw, zw, padding
+  mat4 rotationMatrix;
+  vec4 quatLeft;
+  vec4 quatRight;
+};
+
+layout(std140) uniform StyleUniforms {
+  vec4 metricsA; // energy, spatial, hyperspatial, harmonic
+  vec4 metricsB; // saturation, brightness, thickness, chaos
+};
+
+uniform float u_projectionDepth;
+uniform float u_lineWidth;
+uniform float u_time;
+uniform int u_projectionMode;
+uniform vec4 u_projectionParams;
+uniform int u_rotationMode;
+
+out vec3 v_color;
+out float v_depth;
+out float v_energy;
+out float v_thickness;
+out float v_chaos;
+out float v_harmonic;
+out float v_isoclinic;
+out float v_chiral;
+
+vec3 spectralPalette(float parameter) {
+  float hue = parameter;
+  return vec3(
+    0.60 + 0.38 * cos(6.2831 * hue),
+    0.62 + 0.36 * cos(6.2831 * hue + 2.094),
+    0.64 + 0.34 * cos(6.2831 * hue + 4.188)
+  );
+}
+
+vec2 rotatePlane(vec2 plane, float angle) {
+  float c = cos(angle);
+  float s = sin(angle);
+  return vec2(
+    plane.x * c - plane.y * s,
+    plane.x * s + plane.y * c
+  );
+}
+
+vec4 quatMultiply(vec4 a, vec4 b) {
+  return vec4(
+    a.w * b.x + a.x * b.w + a.y * b.z - a.z * b.y,
+    a.w * b.y - a.x * b.z + a.y * b.w + a.z * b.x,
+    a.w * b.z + a.x * b.y - a.y * b.x + a.z * b.w,
+    a.w * b.w - a.x * b.x - a.y * b.y - a.z * b.z
+  );
+}
+
+vec4 quatConjugate(vec4 q) {
+  return vec4(-q.xyz, q.w);
+}
+
+vec4 quatNormalize(vec4 q) {
+  float len = length(q);
+  if (len == 0.0) {
+    return vec4(0.0, 0.0, 0.0, 1.0);
+  }
+  return q / len;
+}
+
+vec4 applySixPlaneRotation(vec4 position, vec4 spatialAngles, vec4 hyperAngles) {
+  vec4 rotated = position;
+
+  vec2 pairXY = rotatePlane(rotated.xy, spatialAngles.x);
+  rotated.x = pairXY.x;
+  rotated.y = pairXY.y;
+
+  vec2 pairXZ = rotatePlane(vec2(rotated.x, rotated.z), spatialAngles.y);
+  rotated.x = pairXZ.x;
+  rotated.z = pairXZ.y;
+
+  vec2 pairYZ = rotatePlane(vec2(rotated.y, rotated.z), spatialAngles.z);
+  rotated.y = pairYZ.x;
+  rotated.z = pairYZ.y;
+
+  vec2 pairXW = rotatePlane(vec2(rotated.x, rotated.w), hyperAngles.x);
+  rotated.x = pairXW.x;
+  rotated.w = pairXW.y;
+
+  vec2 pairYW = rotatePlane(vec2(rotated.y, rotated.w), hyperAngles.y);
+  rotated.y = pairYW.x;
+  rotated.w = pairYW.y;
+
+  vec2 pairZW = rotatePlane(vec2(rotated.z, rotated.w), hyperAngles.z);
+  rotated.z = pairZW.x;
+  rotated.w = pairZW.y;
+
+  return rotated;
+}
+
+vec4 applyDualQuaternion(vec4 position, vec4 left, vec4 right) {
+  vec4 normLeft = quatNormalize(left);
+  vec4 normRight = quatNormalize(right);
+  vec4 temp = quatMultiply(normLeft, position);
+  return quatMultiply(temp, quatConjugate(normRight));
+}
+
+vec3 projectTo3D(vec4 rotated, out float depthValue) {
+  if (u_projectionMode == 0) {
+    float depth = max(u_projectionParams.x - rotated.w, u_projectionParams.y);
+    depthValue = depth;
+    return rotated.xyz / depth;
+  }
+  if (u_projectionMode == 1) {
+    float denom = max(u_projectionParams.x - rotated.w, u_projectionParams.y);
+    depthValue = denom;
+    return rotated.xyz / denom * u_projectionParams.z;
+  }
+  depthValue = max(u_projectionDepth, 0.2);
+  return rotated.xyz * u_projectionParams.w;
+}
+
+void main() {
+  vec4 rotated = a_position4d;
+  if (u_rotationMode == 0) {
+    rotated = applySixPlaneRotation(rotated, spatial, hyperspatial);
+  } else {
+    rotated = applyDualQuaternion(rotated, quatLeft, quatRight);
+  }
+  vec4 matrixProjected = rotationMatrix * rotated;
+  float depth;
+  vec3 projected = projectTo3D(rotated, depth);
+  gl_Position = vec4(projected.xy, projected.z * 0.5, 1.0);
+  gl_PointSize = 4.0;
+
+  float energy = metricsA.x;
+  float harmonicBase = metricsA.w;
+  float saturation = metricsB.x;
+  float brightness = metricsB.y;
+  float thickness = metricsB.z;
+  float chaos = metricsB.w;
+
+  float isoclinicDot = clamp(dot(quatLeft, quatRight), -1.0, 1.0);
+  float isoPhase = isoclinicDot * 0.5 + 0.5;
+  vec3 leftVec = quatLeft.xyz;
+  vec3 rightVec = quatRight.xyz;
+  float chiralSpread = length(leftVec - rightVec);
+  float chiralTone = smoothstep(0.0, 1.4, clamp(chiralSpread, 0.0, 2.0));
+
+  float hueShift = chaos * 0.12 + energy * 0.08 + (isoPhase - 0.5) * 0.18;
+  float isoSaturation = clamp(saturation + (isoPhase - 0.5) * 0.22, 0.0, 1.0);
+  float isoBrightness = clamp(brightness + (1.0 - chiralTone) * 0.12, 0.0, 1.0);
+  float isoThickness = thickness * (1.0 + chiralTone * 0.45);
+  float isoChaos = clamp(chaos + chiralTone * 0.35, 0.0, 1.0);
+  float isoEnergy = clamp(mix(energy, 1.0, chiralTone * 0.15), 0.0, 1.0);
+
+  float geometricMix = dot(rotated, vec4(0.12, 0.18, 0.24, 0.3));
+  geometricMix += dot(matrixProjected, rotated) * 0.01;
+  float harmonic = fract(harmonicBase + geometricMix * 0.12 + isoPhase * 0.33);
+  vec3 baseColor = spectralPalette(fract(harmonic + hueShift));
+  vec3 neutral = vec3(isoBrightness);
+  float contour = 0.35 + 0.65 * smoothstep(0.0, u_projectionDepth, depth);
+
+  v_color = mix(neutral, baseColor, isoSaturation) * contour;
+  v_depth = depth;
+  v_energy = isoEnergy;
+  v_thickness = isoThickness;
+  v_chaos = isoChaos;
+  v_harmonic = harmonic;
+  v_isoclinic = isoPhase;
+  v_chiral = chiralTone;
+}
+`;
+
+const FRAGMENT_SHADER = `
+precision highp float;
+
+layout(std140) uniform StyleUniforms {
+  vec4 metricsA;
+  vec4 metricsB;
+};
+
+uniform float u_time;
+uniform float u_lineWidth;
+
+in vec3 v_color;
+in float v_depth;
+in float v_energy;
+in float v_thickness;
+in float v_chaos;
+in float v_harmonic;
+in float v_isoclinic;
+in float v_chiral;
+
+out vec4 fragColor;
+
+float hash(vec2 p) {
+  return fract(sin(dot(p, vec2(127.1, 311.7))) * 43758.5453);
+}
+
+void main() {
+  float energy = v_energy;
+  float chaos = v_chaos;
+  float harmonic = v_harmonic;
+  float shimmerBase = 0.65 + 0.35 * sin(u_time * (0.9 + energy * 0.8) + harmonic * 6.2831);
+  float shimmer = shimmerBase * mix(0.85, 1.22, v_isoclinic);
+  float depthFade = smoothstep(1.2, 0.1, v_depth);
+  float noiseSample = hash(gl_FragCoord.xy * (0.003 + chaos * 0.02));
+  float noise = mix(-0.08, 0.14, noiseSample) * chaos * mix(0.45, 1.05, v_chiral);
+  float widthPulse = 0.82 + 0.38 * sin(u_time * (1.3 + v_isoclinic * 0.7) + v_thickness * 1.05);
+
+  vec3 color = (v_color + vec3(0.08, 0.15, 0.32) * v_chiral) * shimmer * (0.7 + depthFade * 0.5);
+  color += vec3(noise);
+  float alpha = clamp(0.24 + energy * 0.58 + chaos * 0.17 + v_chiral * 0.2, 0.2, 1.0);
+
+  fragColor = vec4(color * widthPulse, alpha);
+}
+`;

--- a/src/core/projectionBridge.test.ts
+++ b/src/core/projectionBridge.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildProjectionUniforms,
+  DEFAULT_PROJECTION_PARAMETERS,
+  projectionModeToIndex,
+  type ProjectionMode,
+  updateProjectionParameter
+} from './projectionBridge';
+
+const MODES: ProjectionMode[] = ['perspective', 'stereographic', 'orthographic'];
+
+describe('projectionBridge', () => {
+  it('maps projection modes to stable indices', () => {
+    const indices = MODES.map((mode) => projectionModeToIndex(mode));
+    expect(new Set(indices).size).toBe(MODES.length);
+    for (const index of indices) {
+      expect(index).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  it('builds uniform data with sane defaults', () => {
+    const target = new Float32Array(4);
+    const { mode, params } = buildProjectionUniforms('perspective', DEFAULT_PROJECTION_PARAMETERS, target);
+    expect(mode).toBe(projectionModeToIndex('perspective'));
+    expect(params).toBe(target);
+    expect(params[0]).toBeGreaterThan(params[1]);
+    expect(params[2]).toBeGreaterThan(0);
+    expect(params[3]).toBeGreaterThan(0);
+  });
+
+  it('updates projection parameters based on mode', () => {
+    let params = { ...DEFAULT_PROJECTION_PARAMETERS };
+    params = updateProjectionParameter('perspective', params, 4);
+    expect(params.depth).toBe(4);
+
+    params = updateProjectionParameter('stereographic', params, 2.5);
+    expect(params.stereographicScale).toBeCloseTo(2.5);
+
+    params = updateProjectionParameter('orthographic', params, 1.2);
+    expect(params.orthographicScale).toBeCloseTo(1.2);
+  });
+});

--- a/src/core/projectionBridge.ts
+++ b/src/core/projectionBridge.ts
@@ -1,0 +1,79 @@
+import { clamp } from '../utils/math';
+
+export type ProjectionMode = 'perspective' | 'stereographic' | 'orthographic';
+
+export interface ProjectionParameters {
+  /** For perspective and stereographic projection this acts as the camera depth */
+  depth: number;
+  /** Minimum denominator to avoid division by zero */
+  epsilon: number;
+  /** Strength multiplier for stereographic projection */
+  stereographicScale: number;
+  /** Scale applied during orthographic projection */
+  orthographicScale: number;
+}
+
+export interface ProjectionUniforms {
+  mode: number;
+  params: Float32Array;
+}
+
+export const DEFAULT_PROJECTION_PARAMETERS: ProjectionParameters = {
+  depth: 3,
+  epsilon: 0.2,
+  stereographicScale: 1,
+  orthographicScale: 0.8
+};
+
+export function projectionModeToIndex(mode: ProjectionMode): number {
+  switch (mode) {
+    case 'perspective':
+      return 0;
+    case 'stereographic':
+      return 1;
+    case 'orthographic':
+      return 2;
+    default:
+      return 0;
+  }
+}
+
+export function buildProjectionUniforms(
+  mode: ProjectionMode,
+  params: ProjectionParameters,
+  target: Float32Array = new Float32Array(4)
+): ProjectionUniforms {
+  const uniforms: ProjectionUniforms = {
+    mode: projectionModeToIndex(mode),
+    params: target
+  };
+
+  const depth = Math.max(params.depth, params.epsilon);
+  const epsilon = clamp(params.epsilon, 1e-4, depth);
+  const stereoScale = Math.max(params.stereographicScale, 0.01);
+  const orthoScale = Math.max(params.orthographicScale, 0.01);
+
+  target[0] = depth;
+  target[1] = epsilon;
+  target[2] = stereoScale;
+  target[3] = orthoScale;
+
+  return uniforms;
+}
+
+export function updateProjectionParameter(
+  mode: ProjectionMode,
+  params: ProjectionParameters,
+  value: number
+): ProjectionParameters {
+  switch (mode) {
+    case 'perspective':
+      return { ...params, depth: Math.max(value, params.epsilon) };
+    case 'stereographic':
+      return { ...params, stereographicScale: Math.max(value, 0.01) };
+    case 'orthographic':
+      return { ...params, orthographicScale: Math.max(value, 0.01) };
+    default:
+      return params;
+  }
+}

--- a/src/core/rotationDynamics.test.ts
+++ b/src/core/rotationDynamics.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import { deriveRotationDynamics } from './rotationDynamics';
+import { ZERO_ROTATION } from './rotationUniforms';
+
+const randomAngle = () => (Math.random() - 0.5) * Math.PI * 2;
+
+describe('deriveRotationDynamics', () => {
+  it('returns zero energy for zero rotation', () => {
+    const dynamics = deriveRotationDynamics(ZERO_ROTATION);
+    expect(dynamics.energy).toBe(0);
+    expect(dynamics.spatial).toBe(0);
+    expect(dynamics.hyperspatial).toBe(0);
+    expect(dynamics.harmonic).toBeGreaterThanOrEqual(0);
+    expect(dynamics.harmonic).toBeLessThanOrEqual(1);
+  });
+
+  it('responds to spatial and hyperspatial planes differently', () => {
+    const spatialOnly = deriveRotationDynamics({
+      xy: Math.PI / 2,
+      xz: 0,
+      yz: 0,
+      xw: 0,
+      yw: 0,
+      zw: 0
+    });
+
+    const hyperOnly = deriveRotationDynamics({
+      xy: 0,
+      xz: 0,
+      yz: 0,
+      xw: Math.PI / 2,
+      yw: 0,
+      zw: 0
+    });
+
+    expect(spatialOnly.spatial).toBeGreaterThan(hyperOnly.spatial);
+    expect(hyperOnly.hyperspatial).toBeGreaterThan(spatialOnly.hyperspatial);
+  });
+
+  it('produces normalized metrics within expected bounds', () => {
+    for (let i = 0; i < 32; i += 1) {
+      const dynamics = deriveRotationDynamics({
+        xy: randomAngle(),
+        xz: randomAngle(),
+        yz: randomAngle(),
+        xw: randomAngle(),
+        yw: randomAngle(),
+        zw: randomAngle()
+      });
+
+      expect(dynamics.energy).toBeGreaterThanOrEqual(0);
+      expect(dynamics.energy).toBeLessThanOrEqual(1);
+      expect(dynamics.spatial).toBeGreaterThanOrEqual(0);
+      expect(dynamics.spatial).toBeLessThanOrEqual(1);
+      expect(dynamics.hyperspatial).toBeGreaterThanOrEqual(0);
+      expect(dynamics.hyperspatial).toBeLessThanOrEqual(1);
+      expect(dynamics.saturation).toBeGreaterThanOrEqual(0);
+      expect(dynamics.saturation).toBeLessThanOrEqual(1);
+      expect(dynamics.brightness).toBeGreaterThanOrEqual(0);
+      expect(dynamics.brightness).toBeLessThanOrEqual(1);
+      expect(dynamics.chaos).toBeGreaterThanOrEqual(0);
+      expect(dynamics.chaos).toBeLessThanOrEqual(1);
+      expect(dynamics.thickness).toBeGreaterThan(0);
+    }
+  });
+});

--- a/src/core/rotationDynamics.ts
+++ b/src/core/rotationDynamics.ts
@@ -1,0 +1,103 @@
+import { type RotationAngles } from './rotationUniforms';
+import { composeDualQuaternion } from './so4';
+import { type RotationDynamics, ZERO_DYNAMICS } from './styleUniforms';
+
+const SQRT_THREE = Math.sqrt(3);
+const SQRT_SIX = Math.sqrt(6);
+const MAX_PLANE_MAGNITUDE = Math.PI * SQRT_THREE;
+const MAX_TOTAL_MAGNITUDE = Math.PI * SQRT_SIX;
+
+function clamp01(value: number): number {
+  if (value <= 0) return 0;
+  if (value >= 1) return 1;
+  return value;
+}
+
+const scratchLeft = new Float32Array(4);
+const scratchRight = new Float32Array(4);
+
+export function deriveRotationDynamics(angles: RotationAngles): RotationDynamics {
+  const spatialVector = [angles.xy, angles.xz, angles.yz];
+  const hypersVector = [angles.xw, angles.yw, angles.zw];
+
+  const spatialMagnitude = Math.hypot(...spatialVector);
+  const hypersMagnitude = Math.hypot(...hypersVector);
+  const totalMagnitude = Math.hypot(
+    spatialVector[0],
+    spatialVector[1],
+    spatialVector[2],
+    hypersVector[0],
+    hypersVector[1],
+    hypersVector[2]
+  );
+
+  const energyRaw = clamp01(totalMagnitude / MAX_TOTAL_MAGNITUDE);
+  const spatial = clamp01(spatialMagnitude / MAX_PLANE_MAGNITUDE);
+  const hyperspatial = clamp01(hypersMagnitude / MAX_PLANE_MAGNITUDE);
+
+  const interference =
+    Math.sin(angles.xy * 0.5) +
+    Math.sin(angles.xz * 0.33 + angles.yw * 0.25) +
+    Math.sin(angles.yz * 0.42 - angles.zw * 0.37);
+  const harmonicWave = (interference / 3 + 1) * 0.5;
+
+  const dual = composeDualQuaternion(angles, scratchLeft, scratchRight);
+  const dot =
+    dual.left[0] * dual.right[0] +
+    dual.left[1] * dual.right[1] +
+    dual.left[2] * dual.right[2] +
+    dual.left[3] * dual.right[3];
+  const isoclinic = clamp01((dot + 1) * 0.5);
+  const chiralSpread = clamp01(
+    Math.hypot(
+      dual.left[0] - dual.right[0],
+      dual.left[1] - dual.right[1],
+      dual.left[2] - dual.right[2],
+      dual.left[3] - dual.right[3]
+    ) * 0.5
+  );
+
+  const harmonic = clamp01(0.55 * harmonicWave + 0.45 * isoclinic);
+
+  const saturation = clamp01(
+    0.28 +
+      energyRaw * 0.6 +
+      0.18 * (harmonic - 0.5) +
+      (isoclinic - 0.5) * 0.12
+  );
+  const brightness = clamp01(
+    0.34 +
+      0.42 * (1 - Math.abs(harmonic - 0.5) * 1.5) +
+      0.08 * (1 - chiralSpread)
+  );
+
+  const thicknessRaw =
+    0.7 +
+    energyRaw * 1.15 +
+    (spatial - hyperspatial) * 0.32 +
+    chiralSpread * 0.48;
+  const thickness = Math.min(Math.max(thicknessRaw, 0.45), 2.6);
+
+  const chaos = clamp01(
+    Math.abs(spatial - hyperspatial) * 0.7 +
+      energyRaw * 0.22 +
+      chiralSpread * 0.48
+  );
+
+  const energy = clamp01(energyRaw * (0.88 + chiralSpread * 0.18));
+
+  return {
+    energy,
+    spatial,
+    hyperspatial,
+    harmonic,
+    saturation,
+    brightness,
+    thickness,
+    chaos
+  };
+}
+
+export function dynamicsToUniformSafe(dynamics: RotationDynamics | null | undefined): RotationDynamics {
+  return dynamics ?? ZERO_DYNAMICS;
+}

--- a/src/core/rotationUniforms.test.ts
+++ b/src/core/rotationUniforms.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { mat4 } from 'gl-matrix';
+import { packRotationUniformData, ZERO_ROTATION } from './rotationUniforms';
+import { composeDualQuaternion, rotationMatrixFromAngles } from './so4';
+
+const ANGLES = {
+  xy: 0.4,
+  xz: -0.7,
+  yz: 0.2,
+  xw: -0.5,
+  yw: 1.0,
+  zw: -0.3
+};
+
+describe('packRotationUniformData', () => {
+  it('writes angles, matrix, and dual quaternions into the target buffer', () => {
+    const target = new Float32Array(32);
+    const matrixOut = mat4.create();
+    const leftQuat = new Float32Array(4);
+    const rightQuat = new Float32Array(4);
+
+    packRotationUniformData(ANGLES, target, matrixOut, leftQuat, rightQuat);
+
+    expect(target[0]).toBeCloseTo(ANGLES.xy, 1e-6);
+    expect(target[1]).toBeCloseTo(ANGLES.xz, 1e-6);
+    expect(target[2]).toBeCloseTo(ANGLES.yz, 1e-6);
+    expect(target[4]).toBeCloseTo(ANGLES.xw, 1e-6);
+    expect(target[5]).toBeCloseTo(ANGLES.yw, 1e-6);
+    expect(target[6]).toBeCloseTo(ANGLES.zw, 1e-6);
+
+    const expectedMatrix = rotationMatrixFromAngles(ANGLES);
+    for (let i = 0; i < 16; i += 1) {
+      expect(target[8 + i]).toBeCloseTo(expectedMatrix[i], 1e-5);
+    }
+
+    const expectedDual = composeDualQuaternion(ANGLES);
+    for (let i = 0; i < 4; i += 1) {
+      expect(target[24 + i]).toBeCloseTo(expectedDual.left[i], 1e-5);
+      expect(target[28 + i]).toBeCloseTo(expectedDual.right[i], 1e-5);
+    }
+  });
+
+  it('handles zero rotation without producing NaNs', () => {
+    const target = new Float32Array(32);
+    const matrixOut = mat4.create();
+    const leftQuat = new Float32Array(4);
+    const rightQuat = new Float32Array(4);
+
+    packRotationUniformData(ZERO_ROTATION, target, matrixOut, leftQuat, rightQuat);
+
+    for (let i = 0; i < target.length; i += 1) {
+      expect(Number.isNaN(target[i])).toBe(false);
+      expect(Number.isFinite(target[i])).toBe(true);
+    }
+  });
+});

--- a/src/core/rotationUniforms.ts
+++ b/src/core/rotationUniforms.ts
@@ -1,0 +1,97 @@
+import { mat4 } from 'gl-matrix';
+import { composeDualQuaternion, rotationMatrixFromAngles } from './so4';
+
+export interface RotationAngles {
+  xy: number;
+  xz: number;
+  yz: number;
+  xw: number;
+  yw: number;
+  zw: number;
+}
+
+export interface RotationSnapshot extends RotationAngles {
+  timestamp: number;
+  confidence: number;
+}
+
+export interface RotationDualQuaternion {
+  left: Float32Array;
+  right: Float32Array;
+}
+
+const FLOATS_PER_BLOCK = 32; // vec4 + vec4 + mat4 + vec4 + vec4
+const BLOCK_SIZE_BYTES = FLOATS_PER_BLOCK * 4;
+const MATRIX_OFFSET = 8;
+const LEFT_QUAT_OFFSET = 24;
+const RIGHT_QUAT_OFFSET = 28;
+
+export function packRotationUniformData(
+  angles: RotationAngles,
+  target: Float32Array,
+  matrixOut: mat4,
+  leftQuatOut: Float32Array,
+  rightQuatOut: Float32Array
+) {
+  target[0] = angles.xy;
+  target[1] = angles.xz;
+  target[2] = angles.yz;
+  target[3] = 0.0; // padding
+  target[4] = angles.xw;
+  target[5] = angles.yw;
+  target[6] = angles.zw;
+  target[7] = 0.0; // padding
+
+  const matrix = rotationMatrixFromAngles(angles, matrixOut);
+  target.set(matrix, MATRIX_OFFSET);
+
+  const dual = composeDualQuaternion(angles, leftQuatOut, rightQuatOut);
+  target.set(dual.left, LEFT_QUAT_OFFSET);
+  target.set(dual.right, RIGHT_QUAT_OFFSET);
+}
+
+export class RotationUniformBuffer {
+  private readonly buffer: WebGLBuffer;
+  private readonly data: Float32Array;
+  private readonly matrix = mat4.create();
+  private readonly leftQuat = new Float32Array(4);
+  private readonly rightQuat = new Float32Array(4);
+
+  constructor(private readonly gl: WebGL2RenderingContext) {
+    const buffer = gl.createBuffer();
+    if (!buffer) {
+      throw new Error('Failed to allocate rotation uniform buffer');
+    }
+    this.buffer = buffer;
+    this.data = new Float32Array(FLOATS_PER_BLOCK);
+
+    gl.bindBufferBase(gl.UNIFORM_BUFFER, 0, buffer);
+    gl.bufferData(gl.UNIFORM_BUFFER, BLOCK_SIZE_BYTES, gl.DYNAMIC_DRAW);
+  }
+
+  bind(program: WebGLProgram, blockName = 'RotationUniforms', bindingIndex = 0) {
+    const { gl } = this;
+    const blockIndex = gl.getUniformBlockIndex(program, blockName);
+    if (blockIndex === gl.INVALID_INDEX) {
+      throw new Error(`Program is missing uniform block ${blockName}`);
+    }
+    gl.uniformBlockBinding(program, blockIndex, bindingIndex);
+    gl.bindBufferBase(gl.UNIFORM_BUFFER, bindingIndex, this.buffer);
+  }
+
+  update(angles: RotationAngles) {
+    const { data, gl } = this;
+    packRotationUniformData(angles, data, this.matrix, this.leftQuat, this.rightQuat);
+    gl.bindBuffer(gl.UNIFORM_BUFFER, this.buffer);
+    gl.bufferSubData(gl.UNIFORM_BUFFER, 0, data);
+  }
+}
+
+export const ZERO_ROTATION: RotationAngles = {
+  xy: 0,
+  xz: 0,
+  yz: 0,
+  xw: 0,
+  yw: 0,
+  zw: 0
+};

--- a/src/core/sixPlaneOrbit.test.ts
+++ b/src/core/sixPlaneOrbit.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { createHarmonicOrbit, SIX_PLANE_KEYS } from './sixPlaneOrbit';
+
+describe('six plane harmonic orbit', () => {
+  it('produces bounded angles for each plane', () => {
+    const orbit = createHarmonicOrbit();
+    const angles = orbit(1.234);
+    for (const plane of SIX_PLANE_KEYS) {
+      expect(angles[plane]).toBeLessThanOrEqual(Math.PI);
+      expect(angles[plane]).toBeGreaterThanOrEqual(-Math.PI);
+    }
+  });
+
+  it('reacts smoothly across time samples', () => {
+    const orbit = createHarmonicOrbit();
+    const early = orbit(0.25);
+    const late = orbit(0.30);
+    for (const plane of SIX_PLANE_KEYS) {
+      expect(Math.abs(late[plane] - early[plane])).toBeLessThan(0.5);
+    }
+  });
+});

--- a/src/core/sixPlaneOrbit.ts
+++ b/src/core/sixPlaneOrbit.ts
@@ -1,0 +1,83 @@
+import type { RotationAngles } from './rotationUniforms';
+
+const TAU = Math.PI * 2;
+export const SIX_PLANE_KEYS: ReadonlyArray<keyof RotationAngles> = ['xy', 'xz', 'yz', 'xw', 'yw', 'zw'];
+
+export interface OrbitPlane {
+  plane: keyof RotationAngles;
+  ratio: number;
+  amplitude?: number;
+  phase?: number;
+}
+
+export interface OrbitSpec {
+  baseFrequency: number;
+  amplitude: number;
+  planes: OrbitPlane[];
+  coupling?: number;
+  hyperCoupling?: number;
+}
+
+const GOLDEN_RATIO = (1 + Math.sqrt(5)) / 2;
+
+function defaultSpec(): OrbitSpec {
+  return {
+    baseFrequency: 0.12,
+    amplitude: Math.PI / 3.5,
+    coupling: 0.28,
+    hyperCoupling: 0.14,
+    planes: [
+      { plane: 'xy', ratio: 1, amplitude: 1.0 },
+      { plane: 'xz', ratio: GOLDEN_RATIO, amplitude: 0.86, phase: Math.PI / 5 },
+      { plane: 'yz', ratio: 5 / 3, amplitude: 0.92, phase: Math.PI / 2 },
+      { plane: 'xw', ratio: 2, amplitude: 0.74, phase: Math.PI / 7 },
+      { plane: 'yw', ratio: 2 * GOLDEN_RATIO, amplitude: 0.68, phase: Math.PI / 3 },
+      { plane: 'zw', ratio: 3, amplitude: 0.62, phase: Math.PI * 0.77 }
+    ]
+  };
+}
+
+function clampAngle(angle: number, limit = Math.PI): number {
+  if (angle > limit) return limit;
+  if (angle < -limit) return -limit;
+  return angle;
+}
+
+function createZeroAngles(): RotationAngles {
+  return { xy: 0, xz: 0, yz: 0, xw: 0, yw: 0, zw: 0 };
+}
+
+export function createHarmonicOrbit(spec: OrbitSpec = defaultSpec()): (timeSeconds: number) => RotationAngles {
+  const { amplitude, baseFrequency, planes, coupling = 0, hyperCoupling = 0 } = spec;
+  const resolvedPlanes = planes.length ? planes : defaultSpec().planes;
+
+  return (timeSeconds: number) => {
+    const angles = createZeroAngles();
+
+    for (const planeSpec of resolvedPlanes) {
+      const planeAmplitude = amplitude * (planeSpec.amplitude ?? 1);
+      const phase = planeSpec.phase ?? 0;
+      const omega = TAU * baseFrequency * planeSpec.ratio;
+      const value = planeAmplitude * Math.sin(omega * timeSeconds + phase);
+      angles[planeSpec.plane] = clampAngle(value);
+    }
+
+    if (coupling !== 0) {
+      const spatialMean = (angles.xy + angles.xz + angles.yz) / 3;
+      const hyperMean = (angles.xw + angles.yw + angles.zw) / 3;
+      const bias = (spatialMean - hyperMean) * coupling;
+      angles.xw = clampAngle(angles.xw + bias * 0.8);
+      angles.yw = clampAngle(angles.yw - bias * 0.5);
+      angles.zw = clampAngle(angles.zw + bias * 0.3);
+    }
+
+    if (hyperCoupling !== 0) {
+      const cross = (angles.xy - angles.yz) * hyperCoupling;
+      angles.xw = clampAngle(angles.xw + cross * 0.6);
+      angles.yw = clampAngle(angles.yw + cross * 0.4);
+      angles.zw = clampAngle(angles.zw - cross * 0.2);
+    }
+
+    return angles;
+  };
+}

--- a/src/core/so4.test.ts
+++ b/src/core/so4.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { vec4, mat4 } from 'gl-matrix';
+import { applyDualQuaternionRotation, applySequentialRotations, composeDualQuaternion, rotationMatrixFromAngles } from './so4';
+import type { RotationAngles } from './rotationUniforms';
+
+const ANGLES: RotationAngles = {
+  xy: 0.5,
+  xz: -0.3,
+  yz: 0.8,
+  xw: -0.2,
+  yw: 1.1,
+  zw: 0.4
+};
+
+describe('SO(4) rotations', () => {
+  it('matches matrix multiplication with sequential rotations', () => {
+    const vector = vec4.fromValues(0.25, -0.4, 0.7, -0.2);
+    const sequential = applySequentialRotations(vector, ANGLES);
+
+    const matrix = rotationMatrixFromAngles(ANGLES);
+    const matrixResult = vec4.transformMat4(vec4.create(), vector, matrix);
+
+    for (let i = 0; i < 4; i++) {
+      expect(sequential[i]).toBeCloseTo(matrixResult[i], 1e-5);
+    }
+  });
+
+  it('produces orthonormal matrix', () => {
+    const matrix = rotationMatrixFromAngles(ANGLES);
+    const transpose = mat4.transpose(mat4.create(), matrix);
+    const product = mat4.multiply(mat4.create(), matrix, transpose);
+    for (let i = 0; i < 4; i++) {
+      for (let j = 0; j < 4; j++) {
+        const expected = i === j ? 1 : 0;
+        expect(product[i * 4 + j]).toBeCloseTo(expected, 1e-5);
+      }
+    }
+  });
+
+  it('can reuse matrix output buffer', () => {
+    const out = mat4.create();
+    const result = rotationMatrixFromAngles(ANGLES, out);
+    expect(result).toBe(out);
+  });
+
+  it('matches dual quaternion rotation', () => {
+    const vector = vec4.fromValues(-0.12, 0.51, -0.33, 0.9);
+    const sequential = applySequentialRotations(vector, ANGLES);
+    const dual = composeDualQuaternion(ANGLES);
+    const dualResult = applyDualQuaternionRotation(vector, dual);
+
+    for (let i = 0; i < 4; i++) {
+      expect(dualResult[i]).toBeCloseTo(sequential[i], 1e-4);
+    }
+  });
+});

--- a/src/core/so4.ts
+++ b/src/core/so4.ts
@@ -1,0 +1,268 @@
+import { mat4, vec4 } from 'gl-matrix';
+import type { RotationAngles, RotationDualQuaternion } from './rotationUniforms';
+
+export function rotationMatrixFromAngles(angles: RotationAngles, out?: mat4): mat4 {
+  const { xy, xz, yz, xw, yw, zw } = angles;
+  const m = out ?? mat4.create();
+  mat4.identity(m);
+
+  applyRotationToMatrix(m, xy, rotateXY);
+  applyRotationToMatrix(m, xz, rotateXZ);
+  applyRotationToMatrix(m, yz, rotateYZ);
+  applyRotationToMatrix(m, xw, rotateXW);
+  applyRotationToMatrix(m, yw, rotateYW);
+  applyRotationToMatrix(m, zw, rotateZW);
+
+  return m;
+}
+
+function applyRotationToMatrix(target: mat4, angle: number, generator: (out: mat4, angle: number) => mat4) {
+  if (angle === 0) return;
+  const r = generator(mat4.create(), angle);
+  mat4.multiply(target, r, target);
+}
+
+export function applySequentialRotations(vector: vec4, angles: RotationAngles): vec4 {
+  const result = vec4.clone(vector);
+  rotateXY(result, angles.xy);
+  rotateXZ(result, angles.xz);
+  rotateYZ(result, angles.yz);
+  rotateXW(result, angles.xw);
+  rotateYW(result, angles.yw);
+  rotateZW(result, angles.zw);
+  return result;
+}
+
+function rotateXY(out: vec4, angle: number): vec4;
+function rotateXY(out: mat4, angle: number): mat4;
+function rotateXY(out: vec4 | mat4, angle: number): typeof out {
+  const c = Math.cos(angle);
+  const s = Math.sin(angle);
+  if (out.length === 4) {
+    const [x, y, z, w] = out as vec4;
+    (out as vec4)[0] = x * c - y * s;
+    (out as vec4)[1] = x * s + y * c;
+    (out as vec4)[2] = z;
+    (out as vec4)[3] = w;
+  } else {
+    const m = out as mat4;
+    mat4.identity(m);
+    m[0] = c; m[1] = s;
+    m[4] = -s; m[5] = c;
+  }
+  return out;
+}
+
+function rotateXZ(out: vec4, angle: number): vec4;
+function rotateXZ(out: mat4, angle: number): mat4;
+function rotateXZ(out: vec4 | mat4, angle: number): typeof out {
+  const c = Math.cos(angle);
+  const s = Math.sin(angle);
+  if (out.length === 4) {
+    const [x, y, z, w] = out as vec4;
+    (out as vec4)[0] = x * c - z * s;
+    (out as vec4)[1] = y;
+    (out as vec4)[2] = x * s + z * c;
+    (out as vec4)[3] = w;
+  } else {
+    const m = out as mat4;
+    mat4.identity(m);
+    m[0] = c; m[2] = s;
+    m[8] = -s; m[10] = c;
+  }
+  return out;
+}
+
+function rotateYZ(out: vec4, angle: number): vec4;
+function rotateYZ(out: mat4, angle: number): mat4;
+function rotateYZ(out: vec4 | mat4, angle: number): typeof out {
+  const c = Math.cos(angle);
+  const s = Math.sin(angle);
+  if (out.length === 4) {
+    const [x, y, z, w] = out as vec4;
+    (out as vec4)[0] = x;
+    (out as vec4)[1] = y * c - z * s;
+    (out as vec4)[2] = y * s + z * c;
+    (out as vec4)[3] = w;
+  } else {
+    const m = out as mat4;
+    mat4.identity(m);
+    m[5] = c; m[6] = s;
+    m[9] = -s; m[10] = c;
+  }
+  return out;
+}
+
+function rotateXW(out: vec4, angle: number): vec4;
+function rotateXW(out: mat4, angle: number): mat4;
+function rotateXW(out: vec4 | mat4, angle: number): typeof out {
+  const c = Math.cos(angle);
+  const s = Math.sin(angle);
+  if (out.length === 4) {
+    const [x, y, z, w] = out as vec4;
+    (out as vec4)[0] = x * c - w * s;
+    (out as vec4)[1] = y;
+    (out as vec4)[2] = z;
+    (out as vec4)[3] = x * s + w * c;
+  } else {
+    const m = out as mat4;
+    mat4.identity(m);
+    m[0] = c; m[3] = s;
+    m[12] = -s; m[15] = c;
+  }
+  return out;
+}
+
+function rotateYW(out: vec4, angle: number): vec4;
+function rotateYW(out: mat4, angle: number): mat4;
+function rotateYW(out: vec4 | mat4, angle: number): typeof out {
+  const c = Math.cos(angle);
+  const s = Math.sin(angle);
+  if (out.length === 4) {
+    const [x, y, z, w] = out as vec4;
+    (out as vec4)[0] = x;
+    (out as vec4)[1] = y * c - w * s;
+    (out as vec4)[2] = z;
+    (out as vec4)[3] = y * s + w * c;
+  } else {
+    const m = out as mat4;
+    mat4.identity(m);
+    m[5] = c; m[7] = s;
+    m[13] = -s; m[15] = c;
+  }
+  return out;
+}
+
+function rotateZW(out: vec4, angle: number): vec4;
+function rotateZW(out: mat4, angle: number): mat4;
+function rotateZW(out: vec4 | mat4, angle: number): typeof out {
+  const c = Math.cos(angle);
+  const s = Math.sin(angle);
+  if (out.length === 4) {
+    const [x, y, z, w] = out as vec4;
+    (out as vec4)[0] = x;
+    (out as vec4)[1] = y;
+    (out as vec4)[2] = z * c - w * s;
+    (out as vec4)[3] = z * s + w * c;
+  } else {
+    const m = out as mat4;
+    mat4.identity(m);
+    m[10] = c; m[11] = s;
+    m[14] = -s; m[15] = c;
+  }
+  return out;
+}
+
+export function composeDualQuaternion(
+  angles: RotationAngles,
+  leftOut?: Float32Array,
+  rightOut?: Float32Array
+): RotationDualQuaternion {
+  const { xy, xz, yz, xw, yw, zw } = angles;
+  const left = quaternionFromEuler(xy, xz, yz, leftOut);
+  const right = quaternionFromEuler(xw, yw, zw, rightOut);
+  return { left, right };
+}
+
+export function applyDualQuaternionRotation(
+  vector: vec4,
+  dual: RotationDualQuaternion,
+  out: vec4 = vec4.create()
+): vec4 {
+  const left = copyQuaternion(dual.left, scratchQuaternion0);
+  const right = copyQuaternion(dual.right, scratchQuaternion1);
+  const qVector = quaternionFromVector(vector, scratchQuaternion2);
+  const temp = multiplyQuaternion(quaternionNormalize(left), qVector, scratchQuaternion0);
+  const rightConjugate = conjugateQuaternion(quaternionNormalize(right), scratchQuaternion1);
+  const rotated = multiplyQuaternion(temp, rightConjugate, scratchQuaternion0);
+  out[0] = rotated[0];
+  out[1] = rotated[1];
+  out[2] = rotated[2];
+  out[3] = rotated[3];
+  return out;
+}
+
+function quaternionFromEuler(
+  ax: number,
+  ay: number,
+  az: number,
+  out?: Float32Array
+): Float32Array {
+  const cx = Math.cos(ax * 0.5);
+  const sx = Math.sin(ax * 0.5);
+  const cy = Math.cos(ay * 0.5);
+  const sy = Math.sin(ay * 0.5);
+  const cz = Math.cos(az * 0.5);
+  const sz = Math.sin(az * 0.5);
+
+  const target = out ?? new Float32Array(4);
+  target[0] = sx * cy * cz + cx * sy * sz;
+  target[1] = cx * sy * cz - sx * cy * sz;
+  target[2] = cx * cy * sz + sx * sy * cz;
+  target[3] = cx * cy * cz - sx * sy * sz;
+  return target;
+}
+
+const scratchQuaternion0 = new Float32Array(4);
+const scratchQuaternion1 = new Float32Array(4);
+const scratchQuaternion2 = new Float32Array(4);
+
+function quaternionFromVector(vector: vec4, out: Float32Array) {
+  out[0] = vector[0];
+  out[1] = vector[1];
+  out[2] = vector[2];
+  out[3] = vector[3];
+  return out;
+}
+
+function copyQuaternion(source: Float32Array, out: Float32Array) {
+  out[0] = source[0];
+  out[1] = source[1];
+  out[2] = source[2];
+  out[3] = source[3];
+  return out;
+}
+
+function conjugateQuaternion(quaternion: Float32Array, out: Float32Array) {
+  out[0] = -quaternion[0];
+  out[1] = -quaternion[1];
+  out[2] = -quaternion[2];
+  out[3] = quaternion[3];
+  return out;
+}
+
+function multiplyQuaternion(
+  a: Float32Array,
+  b: Float32Array,
+  out: Float32Array
+) {
+  const ax = a[0];
+  const ay = a[1];
+  const az = a[2];
+  const aw = a[3];
+  const bx = b[0];
+  const by = b[1];
+  const bz = b[2];
+  const bw = b[3];
+
+  out[0] = aw * bx + ax * bw + ay * bz - az * by;
+  out[1] = aw * by - ax * bz + ay * bw + az * bx;
+  out[2] = aw * bz + ax * by - ay * bx + az * bw;
+  out[3] = aw * bw - ax * bx - ay * by - az * bz;
+  return out;
+}
+
+function quaternionNormalize(quaternion: Float32Array) {
+  const length = Math.hypot(quaternion[0], quaternion[1], quaternion[2], quaternion[3]);
+  if (length === 0) {
+    quaternion[3] = 1;
+    quaternion[0] = quaternion[1] = quaternion[2] = 0;
+    return quaternion;
+  }
+  const inv = 1 / length;
+  quaternion[0] *= inv;
+  quaternion[1] *= inv;
+  quaternion[2] *= inv;
+  quaternion[3] *= inv;
+  return quaternion;
+}

--- a/src/core/styleUniforms.ts
+++ b/src/core/styleUniforms.ts
@@ -1,0 +1,73 @@
+export interface RotationDynamics {
+  /** Combined six-plane energy, normalized 0..1 */
+  energy: number;
+  /** Spatial-plane energy (XY/XZ/YZ), normalized 0..1 */
+  spatial: number;
+  /** Hyperspatial-plane energy (XW/YW/ZW), normalized 0..1 */
+  hyperspatial: number;
+  /** Harmonic index 0..1 derived from plane interference */
+  harmonic: number;
+  /** Saturation weighting for color mix 0..1 */
+  saturation: number;
+  /** Brightness weighting 0..1 */
+  brightness: number;
+  /** Dynamic line thickness multiplier (approximately 0.5..2.5) */
+  thickness: number;
+  /** Chaotic modulation 0..1 used for shimmer/noise */
+  chaos: number;
+}
+
+export const ZERO_DYNAMICS: RotationDynamics = {
+  energy: 0,
+  spatial: 0,
+  hyperspatial: 0,
+  harmonic: 0.5,
+  saturation: 0,
+  brightness: 0.35,
+  thickness: 1,
+  chaos: 0
+};
+
+const FLOATS_PER_BLOCK = 8; // vec4 + vec4
+const BLOCK_SIZE_BYTES = FLOATS_PER_BLOCK * 4;
+
+export class StyleUniformBuffer {
+  private readonly buffer: WebGLBuffer;
+  private readonly data: Float32Array;
+
+  constructor(private readonly gl: WebGL2RenderingContext) {
+    const buffer = gl.createBuffer();
+    if (!buffer) {
+      throw new Error('Failed to allocate style uniform buffer');
+    }
+    this.buffer = buffer;
+    this.data = new Float32Array(FLOATS_PER_BLOCK);
+    gl.bindBufferBase(gl.UNIFORM_BUFFER, 1, buffer);
+    gl.bufferData(gl.UNIFORM_BUFFER, BLOCK_SIZE_BYTES, gl.DYNAMIC_DRAW);
+  }
+
+  bind(program: WebGLProgram, blockName = 'StyleUniforms', bindingIndex = 1) {
+    const { gl } = this;
+    const blockIndex = gl.getUniformBlockIndex(program, blockName);
+    if (blockIndex === gl.INVALID_INDEX) {
+      throw new Error(`Program is missing uniform block ${blockName}`);
+    }
+    gl.uniformBlockBinding(program, blockIndex, bindingIndex);
+    gl.bindBufferBase(gl.UNIFORM_BUFFER, bindingIndex, this.buffer);
+  }
+
+  update(dynamics: RotationDynamics) {
+    const { data, gl } = this;
+    data[0] = dynamics.energy;
+    data[1] = dynamics.spatial;
+    data[2] = dynamics.hyperspatial;
+    data[3] = dynamics.harmonic;
+    data[4] = dynamics.saturation;
+    data[5] = dynamics.brightness;
+    data[6] = dynamics.thickness;
+    data[7] = dynamics.chaos;
+
+    gl.bindBuffer(gl.UNIFORM_BUFFER, this.buffer);
+    gl.bufferSubData(gl.UNIFORM_BUFFER, 0, data);
+  }
+}

--- a/src/geometry/tesseract.ts
+++ b/src/geometry/tesseract.ts
@@ -1,0 +1,43 @@
+import type { GeometryData } from './types';
+
+function createTesseractGeometry(): GeometryData {
+  const vertices: number[][] = [];
+  const vertexIndex = new Map<string, number>();
+
+  const coords = [-1, 1];
+  let index = 0;
+  for (const x of coords) {
+    for (const y of coords) {
+      for (const z of coords) {
+        for (const w of coords) {
+          const key = `${x},${y},${z},${w}`;
+          vertices.push([x, y, z, w]);
+          vertexIndex.set(key, index++);
+        }
+      }
+    }
+  }
+
+  const indices: number[] = [];
+  for (let i = 0; i < vertices.length; i++) {
+    const v = vertices[i];
+    for (let axis = 0; axis < 4; axis++) {
+      const neighbor = v.slice();
+      neighbor[axis] *= -1;
+      const neighborKey = neighbor.join(',');
+      const neighborIndex = vertexIndex.get(neighborKey);
+      if (neighborIndex !== undefined && neighborIndex > i) {
+        indices.push(i, neighborIndex);
+      }
+    }
+  }
+
+  return {
+    positions: new Float32Array(vertices.flat()),
+    indices: new Uint16Array(indices),
+    drawMode: WebGL2RenderingContext.LINES,
+    vertexStride: 4
+  };
+}
+
+export const TesseractGeometry = createTesseractGeometry();

--- a/src/geometry/twentyFourCell.ts
+++ b/src/geometry/twentyFourCell.ts
@@ -1,0 +1,54 @@
+import type { GeometryData } from './types';
+
+function createTwentyFourCell(): GeometryData {
+  const vertices: number[][] = [];
+  const vertexIndex = new Map<string, number>();
+
+  const basis = [-1, 1];
+  for (const sign of basis) {
+    for (let axis = 0; axis < 4; axis++) {
+      const v = [0, 0, 0, 0];
+      v[axis] = sign;
+      vertexIndex.set(v.join(','), vertices.push(v) - 1);
+    }
+  }
+
+  const halves = [-0.5, 0.5];
+  for (const x of halves) {
+    for (const y of halves) {
+      for (const z of halves) {
+        for (const w of halves) {
+          const v = [x, y, z, w];
+          vertexIndex.set(v.join(','), vertices.push(v) - 1);
+        }
+      }
+    }
+  }
+
+  const indices: number[] = [];
+  for (let i = 0; i < vertices.length; i++) {
+    for (let j = i + 1; j < vertices.length; j++) {
+      if (Math.abs(distanceSquared(vertices[i], vertices[j]) - 1) < 1e-6) {
+        indices.push(i, j);
+      }
+    }
+  }
+
+  return {
+    positions: new Float32Array(vertices.flat()),
+    indices: new Uint16Array(indices),
+    drawMode: WebGL2RenderingContext.LINES,
+    vertexStride: 4
+  };
+}
+
+function distanceSquared(a: number[], b: number[]): number {
+  let sum = 0;
+  for (let i = 0; i < 4; i++) {
+    const d = a[i] - b[i];
+    sum += d * d;
+  }
+  return sum;
+}
+
+export const TwentyFourCellGeometry = createTwentyFourCell();

--- a/src/geometry/types.ts
+++ b/src/geometry/types.ts
@@ -1,0 +1,12 @@
+export interface GeometryData {
+  positions: Float32Array;
+  indices: Uint16Array;
+  drawMode: number;
+  vertexStride: number;
+}
+
+export interface GeometryDescriptor {
+  id: string;
+  name: string;
+  data: GeometryData;
+}

--- a/src/ingestion/imuMapper.ts
+++ b/src/ingestion/imuMapper.ts
@@ -1,0 +1,55 @@
+import type { RotationAngles, RotationSnapshot } from '../core/rotationUniforms';
+
+export interface ImuPacket {
+  timestamp: number;
+  gyro: [number, number, number];
+  accel: [number, number, number];
+  confidence?: number;
+}
+
+export interface MappingGains {
+  spatial: [number, number, number];
+  hyperspatial: [number, number, number];
+}
+
+export const DEFAULT_GAINS: MappingGains = {
+  spatial: [1, 1, 1],
+  hyperspatial: [0.35, 0.35, 0.35]
+};
+
+export function mapImuPacket(packet: ImuPacket, dt: number, gains: MappingGains = DEFAULT_GAINS): RotationSnapshot {
+  const [gx, gy, gz] = packet.gyro;
+  const [ax, ay, az] = packet.accel;
+
+  const spatial = integrateGyro([gx, gy, gz], dt, gains.spatial);
+  const hyperspatial = projectAcceleration([ax, ay, az], gains.hyperspatial);
+
+  return {
+    xy: spatial[2],
+    xz: spatial[1],
+    yz: spatial[0],
+    xw: hyperspatial[0],
+    yw: hyperspatial[1],
+    zw: hyperspatial[2],
+    timestamp: packet.timestamp,
+    confidence: packet.confidence ?? 1
+  };
+}
+
+function integrateGyro([gx, gy, gz]: [number, number, number], dt: number, gains: [number, number, number]): [number, number, number] {
+  return [
+    gz * dt * gains[2],
+    gy * dt * gains[1],
+    gx * dt * gains[0]
+  ];
+}
+
+function projectAcceleration([ax, ay, az]: [number, number, number], gains: [number, number, number]): [number, number, number] {
+  const gravity = Math.max(Math.hypot(ax, ay, az), 1e-5);
+  const normalized = [ax / gravity, ay / gravity, az / gravity] as [number, number, number];
+  return [
+    normalized[0] * gains[0],
+    normalized[1] * gains[1],
+    normalized[2] * gains[2]
+  ];
+}

--- a/src/ingestion/kerbelizedParserator.test.ts
+++ b/src/ingestion/kerbelizedParserator.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { RotationSnapshot } from '../core/rotationUniforms';
+import { SIX_PLANE_KEYS } from '../core/sixPlaneOrbit';
+import { createConfidenceFloorFilter } from './parserFilters';
+import { KerbelizedParserator } from './kerbelizedParserator';
+import type { ImuPacket } from './imuMapper';
+
+function makeSnapshot(values: number[], confidence = 1): RotationSnapshot {
+  return {
+    xy: values[0],
+    xz: values[1],
+    yz: values[2],
+    xw: values[3],
+    yw: values[4],
+    zw: values[5],
+    timestamp: Date.now(),
+    confidence
+  };
+}
+
+describe('KerbelizedParserator', () => {
+  it('notifies subscribers with filtered frames', () => {
+    const parser = new KerbelizedParserator({ smoothingAlpha: 0.5 });
+    const subscriber = vi.fn();
+    parser.subscribe(subscriber);
+
+    const first = makeSnapshot([1, 0, 0, 0, 0, 0]);
+    parser.ingestRotation(first);
+    expect(subscriber).toHaveBeenCalledTimes(1);
+    expect(subscriber.mock.calls[0][0].rotation.xy).toBeCloseTo(1);
+
+    const second = makeSnapshot([0, 0, 0, 0, 0, 0]);
+    parser.ingestRotation(second);
+    expect(subscriber).toHaveBeenCalledTimes(2);
+    const frame = subscriber.mock.calls[1][0];
+    expect(frame.rotation.xy).toBeLessThan(1);
+    expect(frame.channels[0]).toBeCloseTo(frame.rotation.xy);
+  });
+
+  it('applies focus updates to smoothing filter', () => {
+    const parser = new KerbelizedParserator({ smoothingAlpha: 0.1 });
+    const recorder: RotationSnapshot[] = [];
+    parser.subscribe((frame) => recorder.push(frame.rotation));
+
+    parser.ingestRotation(makeSnapshot([1, 1, 1, 1, 1, 1]));
+    parser.updateFocus({ smoothingAlpha: 1, maxDelta: Infinity });
+    parser.ingestRotation(makeSnapshot([0, 0, 0, 0, 0, 0]));
+
+    expect(recorder[1].xy).toBeCloseTo(0);
+  });
+
+  it('updates confidence floor dynamically', () => {
+    const parser = new KerbelizedParserator({
+      filters: [createConfidenceFloorFilter({ minimum: 0.2 })],
+      minimumConfidence: 0.3
+    });
+    const frames: number[] = [];
+    parser.subscribe((frame) => frames.push(frame.confidence));
+
+    parser.ingestRotation(makeSnapshot([0, 0, 0, 0, 0, 0], 0.1));
+    expect(frames[0]).toBeCloseTo(0.3);
+
+    parser.updateFocus({ minimumConfidence: 0.6 });
+    parser.ingestRotation(makeSnapshot([0, 0, 0, 0, 0, 0], 0.2));
+    expect(frames[1]).toBeCloseTo(0.6);
+  });
+
+  it('packs six-plane rotation into channel buffer', () => {
+    const parser = new KerbelizedParserator();
+    const recorded: Float32Array[] = [];
+    parser.subscribe((frame) => {
+      recorded.push(Float32Array.from(frame.channels));
+    });
+
+    const snapshot = makeSnapshot([0.1, 0.2, 0.3, -0.4, 0.5, -0.6]);
+    parser.ingestRotation(snapshot);
+
+    expect(recorded).toHaveLength(1);
+    const channels = recorded[0];
+    for (let i = 0; i < SIX_PLANE_KEYS.length; i += 1) {
+      expect(channels[i]).toBeCloseTo(snapshot[SIX_PLANE_KEYS[i]]);
+    }
+  });
+
+  it('integrates IMU packets into the rotation stream', () => {
+    const parser = new KerbelizedParserator({ smoothingAlpha: 1 });
+    const frames: RotationSnapshot[] = [];
+    parser.subscribe((frame) => frames.push(frame.rotation));
+
+    const packet: ImuPacket = {
+      timestamp: 10,
+      gyro: [0, 0, 1],
+      accel: [0, 0, 1],
+      confidence: 0.9
+    };
+
+    parser.ingestImuPacket(packet, 0.5);
+    parser.ingestImuPacket({ ...packet, timestamp: 20 }, 0.5);
+
+    expect(frames).toHaveLength(2);
+    expect(frames[1].yz).toBeGreaterThan(frames[0].yz);
+    expect(frames[1].confidence).toBeGreaterThan(0);
+  });
+});
+

--- a/src/ingestion/kerbelizedParserator.ts
+++ b/src/ingestion/kerbelizedParserator.ts
@@ -1,0 +1,160 @@
+import { SIX_PLANE_KEYS } from '../core/sixPlaneOrbit';
+import type { RotationSnapshot } from '../core/rotationUniforms';
+import { DEFAULT_GAINS, type ImuPacket, type MappingGains } from './imuMapper';
+import { So4ImuIntegrator } from './so4Integrator';
+import {
+  type ParserFilter,
+  type ParserFrame,
+  type StatefulParserFilter,
+  createConfidenceFloorFilter,
+  createSmoothingFilter
+} from './parserFilters';
+
+export interface ParseratorOptions {
+  channelCount?: number;
+  gains?: MappingGains;
+  filters?: ParserFilter[];
+  smoothingAlpha?: number;
+  minimumConfidence?: number;
+  hyperSmoothing?: number;
+}
+
+export interface ParseratorFrame extends ParserFrame {}
+
+export type ParseratorSubscriber = (frame: ParseratorFrame) => void;
+
+export interface FocusDirective {
+  smoothingAlpha?: number;
+  reset?: boolean;
+  minimumConfidence?: number;
+  maxDelta?: number;
+}
+
+function cloneRotation(snapshot: RotationSnapshot): RotationSnapshot {
+  return {
+    xy: snapshot.xy,
+    xz: snapshot.xz,
+    yz: snapshot.yz,
+    xw: snapshot.xw,
+    yw: snapshot.yw,
+    zw: snapshot.zw,
+    timestamp: snapshot.timestamp,
+    confidence: snapshot.confidence
+  };
+}
+
+export class KerbelizedParserator {
+  private readonly channelBuffer: Float32Array;
+  private readonly subscribers = new Set<ParseratorSubscriber>();
+  private readonly filters: StatefulParserFilter[];
+  private confidenceFloor: ParserFilter;
+  private gains: MappingGains;
+  private frameId = 0;
+  private readonly integrator: So4ImuIntegrator;
+
+  constructor(options: ParseratorOptions = {}) {
+    const channelCount = options.channelCount ?? 64;
+    if (channelCount < SIX_PLANE_KEYS.length) {
+      throw new Error('Parserator requires at least six channels for SO(4) rotation data');
+    }
+    this.channelBuffer = new Float32Array(channelCount);
+    this.filters = [];
+    this.gains = options.gains ?? { ...DEFAULT_GAINS };
+    this.integrator = new So4ImuIntegrator(this.gains, {
+      hyperSmoothing: options.hyperSmoothing ?? 0.3
+    });
+
+    const smoothing = createSmoothingFilter({ alpha: options.smoothingAlpha ?? 0.18, maxDelta: Math.PI / 8 });
+    this.filters.push(smoothing);
+
+    const userFilters = options.filters ?? [];
+    for (const filter of userFilters) {
+      this.filters.push(filter as StatefulParserFilter);
+    }
+
+    this.confidenceFloor = createConfidenceFloorFilter({ minimum: options.minimumConfidence ?? 0.1 });
+  }
+
+  get channels(): Float32Array {
+    return this.channelBuffer;
+  }
+
+  getGainProfile(): MappingGains {
+    return { spatial: [...this.gains.spatial], hyperspatial: [...this.gains.hyperspatial] };
+  }
+
+  setGainProfile(gains: MappingGains) {
+    this.gains = { spatial: [...gains.spatial], hyperspatial: [...gains.hyperspatial] };
+    this.integrator.setGains(this.gains);
+  }
+
+  subscribe(subscriber: ParseratorSubscriber): () => void {
+    this.subscribers.add(subscriber);
+    return () => this.subscribers.delete(subscriber);
+  }
+
+  ingestRotation(snapshot: RotationSnapshot) {
+    const rotation = cloneRotation(snapshot);
+    const frame = this.createFrame(rotation);
+
+    let filtered: ParserFrame = frame;
+    for (const filter of this.filters) {
+      filtered = filter(filtered);
+    }
+    filtered = this.confidenceFloor(filtered);
+
+    this.notify(filtered);
+  }
+
+  ingestImuPacket(
+    packet: ImuPacket,
+    dt: number,
+    gains: MappingGains = this.gains
+  ): RotationSnapshot {
+    const snapshot = this.integrator.step(packet, dt, gains);
+    this.ingestRotation(snapshot);
+    return snapshot;
+  }
+
+  updateFocus(directive: FocusDirective) {
+    if (directive.reset) {
+      for (const filter of this.filters) {
+        filter.reset?.();
+      }
+      this.integrator.reset();
+    }
+    if (directive.smoothingAlpha !== undefined) {
+      for (const filter of this.filters) {
+        filter.setAlpha?.(directive.smoothingAlpha);
+      }
+    }
+    if (directive.maxDelta !== undefined) {
+      for (const filter of this.filters) {
+        filter.setMaxDelta?.(directive.maxDelta);
+      }
+    }
+    if (directive.minimumConfidence !== undefined) {
+      this.confidenceFloor = createConfidenceFloorFilter({ minimum: directive.minimumConfidence });
+    }
+  }
+
+  private createFrame(rotation: RotationSnapshot): ParserFrame {
+    for (let i = 0; i < SIX_PLANE_KEYS.length; i += 1) {
+      this.channelBuffer[i] = rotation[SIX_PLANE_KEYS[i]];
+    }
+    return {
+      frameId: this.frameId++,
+      timestamp: rotation.timestamp,
+      rotation,
+      channels: this.channelBuffer,
+      confidence: rotation.confidence
+    };
+  }
+
+  private notify(frame: ParserFrame) {
+    for (const subscriber of this.subscribers) {
+      subscriber(frame);
+    }
+  }
+}
+

--- a/src/ingestion/parserFilters.test.ts
+++ b/src/ingestion/parserFilters.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest';
+import type { RotationSnapshot } from '../core/rotationUniforms';
+import { SIX_PLANE_KEYS } from '../core/sixPlaneOrbit';
+import { createConfidenceFloorFilter, createSmoothingFilter } from './parserFilters';
+
+function createSnapshot(value: number): RotationSnapshot {
+  return {
+    xy: value,
+    xz: value,
+    yz: value,
+    xw: value,
+    yw: value,
+    zw: value,
+    timestamp: 0,
+    confidence: 1
+  };
+}
+
+describe('createSmoothingFilter', () => {
+  it('blends incoming rotation with previous frame', () => {
+    const filter = createSmoothingFilter({ alpha: 0.5 });
+    const channels = new Float32Array(SIX_PLANE_KEYS.length);
+
+    const firstFrame = {
+      frameId: 0,
+      timestamp: 0,
+      rotation: createSnapshot(1),
+      channels,
+      confidence: 1
+    } as const;
+
+    const firstResult = filter(firstFrame);
+    expect(firstResult.rotation.xy).toBeCloseTo(1);
+
+    const secondFrame = {
+      frameId: 1,
+      timestamp: 16,
+      rotation: createSnapshot(0),
+      channels,
+      confidence: 1
+    } as const;
+
+    const secondResult = filter(secondFrame);
+    expect(secondResult.rotation.xy).toBeCloseTo(0.5);
+    for (let i = 0; i < SIX_PLANE_KEYS.length; i += 1) {
+      expect(channels[i]).toBeCloseTo(0.5);
+    }
+  });
+
+  it('respects max delta constraints', () => {
+    const filter = createSmoothingFilter({ alpha: 1, maxDelta: 0.1 });
+    const channels = new Float32Array(SIX_PLANE_KEYS.length);
+
+    filter({
+      frameId: 0,
+      timestamp: 0,
+      rotation: createSnapshot(0),
+      channels,
+      confidence: 1
+    });
+
+    const result = filter({
+      frameId: 1,
+      timestamp: 10,
+      rotation: createSnapshot(Math.PI),
+      channels,
+      confidence: 1
+    });
+
+    expect(result.rotation.xy).toBeCloseTo(0.1);
+  });
+});
+
+describe('createConfidenceFloorFilter', () => {
+  it('applies configured minimum confidence', () => {
+    const filter = createConfidenceFloorFilter({ minimum: 0.4 });
+    const frame = {
+      frameId: 0,
+      timestamp: 0,
+      rotation: createSnapshot(0),
+      channels: new Float32Array(SIX_PLANE_KEYS.length),
+      confidence: 0.1
+    } as const;
+
+    const result = filter(frame);
+    expect(result.confidence).toBeCloseTo(0.4);
+    expect(result.rotation.confidence).toBeCloseTo(0.4);
+  });
+});
+

--- a/src/ingestion/parserFilters.ts
+++ b/src/ingestion/parserFilters.ts
@@ -1,0 +1,140 @@
+import type { RotationAngles, RotationSnapshot } from '../core/rotationUniforms';
+import { SIX_PLANE_KEYS } from '../core/sixPlaneOrbit';
+
+export interface ParserFrame {
+  readonly frameId: number;
+  readonly timestamp: number;
+  readonly rotation: RotationSnapshot;
+  readonly channels: Float32Array;
+  readonly confidence: number;
+}
+
+export type ParserFilter = (frame: ParserFrame) => ParserFrame;
+
+export interface StatefulParserFilter extends ParserFilter {
+  reset?(): void;
+  setAlpha?(alpha: number): void;
+  setMaxDelta?(delta: number): void;
+}
+
+function cloneRotation(source: RotationSnapshot): RotationSnapshot {
+  return {
+    xy: source.xy,
+    xz: source.xz,
+    yz: source.yz,
+    xw: source.xw,
+    yw: source.yw,
+    zw: source.zw,
+    timestamp: source.timestamp,
+    confidence: source.confidence
+  };
+}
+
+function blendAngles(target: RotationAngles, current: RotationAngles, alpha: number) {
+  for (const plane of SIX_PLANE_KEYS) {
+    target[plane] = target[plane] + (current[plane] - target[plane]) * alpha;
+  }
+}
+
+export interface SmoothingFilterOptions {
+  /**
+   * Exponential smoothing factor in the range [0, 1].
+   * Lower values favour stability, higher values favour responsiveness.
+   */
+  alpha?: number;
+  /**
+   * Optional clamp to restrict the per-frame delta for any plane.
+   */
+  maxDelta?: number;
+}
+
+function clampAlpha(alpha: number): number {
+  if (!Number.isFinite(alpha)) return 0.2;
+  if (alpha < 0) return 0;
+  if (alpha > 1) return 1;
+  return alpha;
+}
+
+/**
+ * Creates an exponential smoothing filter that blends the incoming rotation with the previous
+ * filtered state. The filter mutates the shared channel buffer so downstream consumers always see
+ * the smoothed six-plane values.
+ */
+export function createSmoothingFilter(options: SmoothingFilterOptions = {}): StatefulParserFilter {
+  let previous: RotationSnapshot | null = null;
+  let alpha = clampAlpha(options.alpha ?? 0.2);
+  let maxDelta = options.maxDelta ?? Infinity;
+
+  const filter: StatefulParserFilter = (frame) => {
+    if (!previous) {
+      previous = cloneRotation(frame.rotation);
+      return frame;
+    }
+
+    const blended = cloneRotation(previous);
+    blendAngles(blended, frame.rotation, alpha);
+
+    if (Number.isFinite(maxDelta)) {
+      for (const plane of SIX_PLANE_KEYS) {
+        const delta = blended[plane] - previous[plane];
+        if (Math.abs(delta) > maxDelta) {
+          blended[plane] = previous[plane] + Math.sign(delta) * maxDelta;
+        }
+      }
+    }
+
+    for (let i = 0; i < SIX_PLANE_KEYS.length; i += 1) {
+      frame.channels[i] = blended[SIX_PLANE_KEYS[i]];
+    }
+
+    blended.confidence = frame.confidence;
+    const blendedConfidence = frame.confidence * 0.85 + previous.confidence * 0.15;
+    previous = { ...blended, confidence: blendedConfidence };
+    return {
+      ...frame,
+      rotation: previous,
+      confidence: blendedConfidence
+    };
+  };
+
+  filter.reset = () => {
+    previous = null;
+  };
+
+  filter.setAlpha = (nextAlpha: number) => {
+    alpha = clampAlpha(nextAlpha);
+  };
+
+  filter.setMaxDelta = (nextDelta: number) => {
+    if (!Number.isFinite(nextDelta) || nextDelta <= 0) {
+      maxDelta = Infinity;
+      return;
+    }
+    maxDelta = nextDelta;
+  };
+
+  return filter;
+}
+
+export interface ConfidenceFloorOptions {
+  minimum?: number;
+}
+
+/**
+ * Ensures the downstream consumers never see confidence fall below a configured floor. This is
+ * useful when sensor dropout would otherwise suppress the visual and sonic response entirely.
+ */
+export function createConfidenceFloorFilter({ minimum = 0.1 }: ConfidenceFloorOptions = {}): ParserFilter {
+  const floor = Math.max(0, Math.min(1, minimum));
+  return (frame) => {
+    if (frame.confidence >= floor) {
+      return frame;
+    }
+    return {
+      ...frame,
+      confidence: floor,
+      rotation: { ...frame.rotation, confidence: floor }
+    };
+  };
+}
+

--- a/src/ingestion/so4Integrator.test.ts
+++ b/src/ingestion/so4Integrator.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import type { ImuPacket } from './imuMapper';
+import { So4ImuIntegrator } from './so4Integrator';
+
+const BASE_PACKET: ImuPacket = {
+  timestamp: 0,
+  gyro: [0, 0, 0],
+  accel: [0, 0, 1],
+  confidence: 0.8
+};
+
+describe('So4ImuIntegrator', () => {
+  it('accumulates spatial rotations over successive packets', () => {
+    const integrator = new So4ImuIntegrator();
+    const packet: ImuPacket = { ...BASE_PACKET, gyro: [0, 0, 1], timestamp: 10 };
+
+    const first = integrator.step(packet, 0.5);
+    expect(first.yz).toBeCloseTo(0.5, 5);
+
+    const second = integrator.step({ ...packet, timestamp: 20 }, 0.5);
+    expect(second.yz).toBeCloseTo(1.0, 5);
+    expect(second.timestamp).toBe(20);
+    expect(second.confidence).toBe(packet.confidence);
+  });
+
+  it('wraps spatial angles within ±π', () => {
+    const integrator = new So4ImuIntegrator();
+    const packet: ImuPacket = { ...BASE_PACKET, gyro: [Math.PI * 2, 0, 0], timestamp: 10 };
+    const result = integrator.step(packet, 1);
+    expect(result.xy).toBeCloseTo(0);
+  });
+
+  it('applies smoothing to hyperspatial measurements', () => {
+    const integrator = new So4ImuIntegrator(undefined, { hyperSmoothing: 0.5 });
+    const packet: ImuPacket = { ...BASE_PACKET, accel: [1, 0, 0], timestamp: 5 };
+    const result = integrator.step(packet, 1);
+    expect(result.xw).toBeGreaterThan(0);
+    expect(result.xw).toBeLessThan(0.35);
+  });
+
+  it('resets to provided angles', () => {
+    const integrator = new So4ImuIntegrator();
+    integrator.step({ ...BASE_PACKET, gyro: [0, 1, 0], timestamp: 1 }, 1);
+    integrator.reset({ xy: 0.2, xz: -0.2, yz: 0.1, xw: 0, yw: 0, zw: 0 });
+    const state = integrator.getAngles();
+    expect(state.xz).toBeCloseTo(-0.2);
+    expect(state.yz).toBeCloseTo(0.1);
+  });
+});

--- a/src/ingestion/so4Integrator.ts
+++ b/src/ingestion/so4Integrator.ts
@@ -1,0 +1,96 @@
+import { ZERO_ROTATION, type RotationAngles, type RotationSnapshot } from '../core/rotationUniforms';
+import { DEFAULT_GAINS, mapImuPacket, type ImuPacket, type MappingGains } from './imuMapper';
+
+export interface So4ImuIntegratorOptions {
+  /**
+   * Blend factor applied when folding accelerometer-derived hyperspatial angles
+   * into the running SO(4) state. 0 applies no update, 1 snaps directly to the
+   * measurement.
+   */
+  hyperSmoothing?: number;
+  /** Maximum absolute angle that will be retained for any plane. */
+  maxMagnitude?: number;
+}
+
+const TAU = Math.PI * 2;
+
+function cloneGains(gains: MappingGains): MappingGains {
+  return {
+    spatial: [...gains.spatial] as [number, number, number],
+    hyperspatial: [...gains.hyperspatial] as [number, number, number]
+  };
+}
+
+function wrapAngle(angle: number): number {
+  if (!Number.isFinite(angle)) return 0;
+  let wrapped = angle % TAU;
+  if (wrapped > Math.PI) wrapped -= TAU;
+  if (wrapped < -Math.PI) wrapped += TAU;
+  return wrapped;
+}
+
+function clampMagnitude(angle: number, maxMagnitude: number): number {
+  if (Math.abs(angle) <= maxMagnitude) return angle;
+  return Math.sign(angle) * maxMagnitude;
+}
+
+function lerp(current: number, target: number, alpha: number): number {
+  return current + (target - current) * alpha;
+}
+
+export class So4ImuIntegrator {
+  private readonly angles: RotationAngles = { ...ZERO_ROTATION };
+  private gains: MappingGains;
+  private hyperSmoothing: number;
+  private readonly maxMagnitude: number;
+
+  constructor(gains: MappingGains = DEFAULT_GAINS, options: So4ImuIntegratorOptions = {}) {
+    this.gains = cloneGains(gains);
+    const smoothing = options.hyperSmoothing ?? 0.25;
+    this.hyperSmoothing = Number.isFinite(smoothing) ? Math.min(Math.max(smoothing, 0), 1) : 0.25;
+    this.maxMagnitude = options.maxMagnitude ?? Math.PI;
+  }
+
+  setGains(gains: MappingGains) {
+    this.gains = cloneGains(gains);
+  }
+
+  reset(angles: RotationAngles = ZERO_ROTATION) {
+    this.angles.xy = angles.xy;
+    this.angles.xz = angles.xz;
+    this.angles.yz = angles.yz;
+    this.angles.xw = angles.xw;
+    this.angles.yw = angles.yw;
+    this.angles.zw = angles.zw;
+  }
+
+  step(packet: ImuPacket, dt: number, gains: MappingGains = this.gains): RotationSnapshot {
+    if (gains !== this.gains) {
+      this.setGains(gains);
+    }
+    const measurement = mapImuPacket(packet, dt, this.gains);
+
+    this.angles.xy = clampMagnitude(wrapAngle(this.angles.xy + measurement.xy), this.maxMagnitude);
+    this.angles.xz = clampMagnitude(wrapAngle(this.angles.xz + measurement.xz), this.maxMagnitude);
+    this.angles.yz = clampMagnitude(wrapAngle(this.angles.yz + measurement.yz), this.maxMagnitude);
+
+    this.angles.xw = clampMagnitude(lerp(this.angles.xw, measurement.xw, this.hyperSmoothing), this.maxMagnitude);
+    this.angles.yw = clampMagnitude(lerp(this.angles.yw, measurement.yw, this.hyperSmoothing), this.maxMagnitude);
+    this.angles.zw = clampMagnitude(lerp(this.angles.zw, measurement.zw, this.hyperSmoothing), this.maxMagnitude);
+
+    return {
+      xy: this.angles.xy,
+      xz: this.angles.xz,
+      yz: this.angles.yz,
+      xw: this.angles.xw,
+      yw: this.angles.yw,
+      zw: this.angles.zw,
+      timestamp: packet.timestamp,
+      confidence: measurement.confidence
+    };
+  }
+
+  getAngles(): RotationAngles {
+    return { ...this.angles };
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,0 +1,419 @@
+import { HypercubeCore } from './core/hypercubeCore';
+import { ZERO_ROTATION, type RotationAngles, type RotationSnapshot } from './core/rotationUniforms';
+import { createHarmonicOrbit, SIX_PLANE_KEYS } from './core/sixPlaneOrbit';
+import { getGeometry, type GeometryId } from './pipeline/geometryCatalog';
+import { RotationBus } from './pipeline/rotationBus';
+import { deriveRotationDynamics } from './core/rotationDynamics';
+import type { RotationDynamics } from './core/styleUniforms';
+import { ExtrumentSynth } from './audio/extrumentSynth';
+import { ImuStream } from './pipeline/imuStream';
+import type { ProjectionMode } from './core/projectionBridge';
+import { KerbelizedParserator } from './ingestion/kerbelizedParserator';
+import { createConfidenceFloorFilter } from './ingestion/parserFilters';
+import { So4ImuIntegrator } from './ingestion/so4Integrator';
+
+const canvas = document.getElementById('gl-canvas') as HTMLCanvasElement;
+const statusEl = document.getElementById('status') as HTMLParagraphElement;
+const geometrySelect = document.getElementById('geometry') as HTMLSelectElement;
+const projectionModeSelect = document.getElementById('projectionMode') as HTMLSelectElement;
+const projectionDepthSlider = document.getElementById('projectionDepth') as HTMLInputElement;
+const projectionDepthLabel = document.getElementById('projectionDepthLabel') as HTMLLabelElement;
+const lineWidthSlider = document.getElementById('lineWidth') as HTMLInputElement;
+const rotationControlsContainer = document.getElementById('rotation-controls') as HTMLDivElement;
+const styleIndicatorsContainer = document.getElementById('style-indicators') as HTMLDivElement;
+const audioToggle = document.getElementById('audio-toggle') as HTMLButtonElement;
+const audioStatus = document.getElementById('audio-status') as HTMLParagraphElement;
+const imuToggle = document.getElementById('imu-toggle') as HTMLButtonElement;
+const imuStatus = document.getElementById('imu-status') as HTMLParagraphElement;
+
+if (
+  !canvas ||
+  !statusEl ||
+  !geometrySelect ||
+  !projectionModeSelect ||
+  !projectionDepthSlider ||
+  !projectionDepthLabel ||
+  !lineWidthSlider ||
+  !rotationControlsContainer ||
+  !styleIndicatorsContainer ||
+  !audioToggle ||
+  !audioStatus ||
+  !imuToggle ||
+  !imuStatus
+) {
+  throw new Error('Required DOM nodes are missing');
+}
+
+let projectionMode = (projectionModeSelect.value as ProjectionMode) ?? 'perspective';
+const projectionControlValues: Record<ProjectionMode, number> = {
+  perspective: Number(projectionDepthSlider.value),
+  stereographic: 1.0,
+  orthographic: 0.8
+};
+
+const core = new HypercubeCore(canvas, {
+  projectionDepth: projectionControlValues.perspective,
+  lineWidth: Number(lineWidthSlider.value),
+  projectionMode
+});
+core.setRotationMode('dual-quaternion');
+initializeProjectionControls();
+core.setProjectionControl(projectionControlValues[projectionMode]);
+if (projectionMode === 'perspective') {
+  core.setProjectionDepth(projectionControlValues.perspective);
+}
+
+const rotationBus = new RotationBus();
+const synth = new ExtrumentSynth();
+const updateIndicators = createStyleIndicators(styleIndicatorsContainer);
+
+rotationBus.subscribe(({ snapshot, dynamics }) => {
+  core.updateRotation(snapshot);
+  core.updateDynamics(dynamics);
+  synth.update(snapshot, dynamics);
+});
+
+let statusBase = 'Geometry: —';
+let rotationSource = 'Harmonic Orbit';
+let latestDynamics: RotationDynamics | null = null;
+
+const parser = new KerbelizedParserator({
+  channelCount: 128,
+  smoothingAlpha: 0.22,
+  minimumConfidence: 0.25,
+  filters: [createConfidenceFloorFilter({ minimum: 0.25 })]
+});
+
+parser.subscribe((frame) => {
+  const { rotation } = frame;
+  latestDynamics = deriveRotationDynamics(rotation);
+  rotationBus.push({ ...rotation }, latestDynamics);
+  updateRotationLabels(rotation, manualOffsets);
+  updateIndicators(latestDynamics);
+  updateStatus(latestDynamics);
+});
+
+const manualOffsets: RotationAngles = { ...ZERO_ROTATION };
+const autoAngles: RotationAngles = { ...ZERO_ROTATION };
+let stopSynthetic: (() => void) | null = null;
+let imuStream: ImuStream | null = null;
+let externalConfidence: number | null = null;
+let externalTimestamp: number | null = null;
+let imuIntegrator: So4ImuIntegrator | null = null;
+
+let updateRotationLabels: (combined: RotationAngles, manual: RotationAngles) => void;
+
+function pushRotationSnapshot(frameTimestamp: number) {
+  let energy = 0;
+  const combined: RotationSnapshot = {
+    ...ZERO_ROTATION,
+    timestamp: externalTimestamp ?? frameTimestamp,
+    confidence: 1
+  };
+
+  for (const plane of SIX_PLANE_KEYS) {
+    combined[plane] = autoAngles[plane] + manualOffsets[plane];
+    energy += Math.abs(combined[plane]);
+  }
+
+  const normalized = Math.min(1, energy / (Math.PI * SIX_PLANE_KEYS.length));
+  const fallbackConfidence = 0.75 + 0.25 * (1 - normalized);
+  combined.confidence = externalConfidence ?? fallbackConfidence;
+
+  parser.ingestRotation(combined);
+}
+
+updateRotationLabels = createRotationControls(rotationControlsContainer, manualOffsets, () => {
+  pushRotationSnapshot(performance.now());
+});
+
+pushRotationSnapshot(performance.now());
+
+function setGeometry(id: GeometryId) {
+  const geometry = getGeometry(id);
+  core.setGeometry(geometry);
+  const vertexCount = (geometry.positions.length / 4).toFixed(0);
+  const edgeCount = (geometry.indices.length / 2).toFixed(0);
+  statusBase = `Geometry: ${id} · vertices ${vertexCount} · edges ${edgeCount}`;
+  if (latestDynamics) {
+    updateStatus(latestDynamics);
+  }
+}
+
+geometrySelect.addEventListener('change', (event) => {
+  const value = (event.target as HTMLSelectElement).value as GeometryId;
+  setGeometry(value);
+});
+
+projectionDepthSlider.addEventListener('input', (event) => {
+  const value = Number((event.target as HTMLInputElement).value);
+  projectionControlValues[projectionMode] = value;
+  if (projectionMode === 'perspective') {
+    core.setProjectionDepth(value);
+  }
+  core.setProjectionControl(value);
+});
+
+projectionModeSelect.addEventListener('change', (event) => {
+  projectionMode = (event.target as HTMLSelectElement).value as ProjectionMode;
+  core.setProjectionMode(projectionMode);
+  updateProjectionControlUi(projectionMode);
+  const controlValue = projectionControlValues[projectionMode];
+  projectionDepthSlider.value = controlValue.toString();
+  if (projectionMode === 'perspective') {
+    core.setProjectionDepth(controlValue);
+  }
+  core.setProjectionControl(controlValue);
+});
+
+lineWidthSlider.addEventListener('input', (event) => {
+  const value = Number((event.target as HTMLInputElement).value);
+  core.setLineWidth(value);
+});
+
+setGeometry('tesseract');
+stopSynthetic = startSyntheticRotation(autoAngles, (timestamp) => pushRotationSnapshot(timestamp));
+core.start();
+
+audioToggle.addEventListener('click', async () => {
+  if (!synth.isActive) {
+    try {
+      await synth.enable();
+      audioToggle.textContent = 'Disable Sonic Weave';
+      audioToggle.classList.add('active');
+      audioStatus.textContent = 'Sonic weave engaged – rotations now sculpt sound.';
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      audioStatus.textContent = `Audio unavailable: ${message}`;
+    }
+  } else {
+    await synth.disable();
+    audioToggle.textContent = 'Enable Sonic Weave';
+    audioToggle.classList.remove('active');
+    audioStatus.textContent = 'Audio engine idle. Click to resume the sonic loom.';
+  }
+});
+
+imuToggle.addEventListener('click', () => {
+  if (!imuStream) {
+    const defaultUrl = localStorage.getItem('imuStreamUrl') ?? 'ws://localhost:7000/imu';
+    const url = prompt('Enter IMU WebSocket URL', defaultUrl);
+    if (!url) {
+      imuStatus.textContent = 'IMU stream connection cancelled.';
+      return;
+    }
+    localStorage.setItem('imuStreamUrl', url);
+    if (stopSynthetic) {
+      stopSynthetic();
+      stopSynthetic = null;
+    }
+    rotationSource = 'IMU Stream';
+    imuToggle.textContent = 'Disconnect IMU Stream';
+    imuToggle.classList.add('active');
+    imuStatus.textContent = 'Connecting to IMU…';
+    externalConfidence = null;
+    externalTimestamp = null;
+    imuStream = new ImuStream({
+      url,
+      onStatus: (status) => {
+        imuStatus.textContent = status;
+        if (latestDynamics) {
+          updateStatus(latestDynamics);
+        }
+      },
+      onPacket: (packet, dt) => {
+        if (!imuIntegrator) {
+          imuIntegrator = new So4ImuIntegrator(parser.getGainProfile());
+        }
+        const snapshot = imuIntegrator.step(packet, dt);
+        for (const plane of SIX_PLANE_KEYS) {
+          autoAngles[plane] = snapshot[plane];
+        }
+        externalConfidence = snapshot.confidence ?? 1;
+        externalTimestamp = snapshot.timestamp;
+        pushRotationSnapshot(performance.now());
+      }
+    });
+    imuStream.start();
+    if (latestDynamics) {
+      updateStatus(latestDynamics);
+    }
+  } else {
+    imuStream.stop();
+    imuStream = null;
+    rotationSource = 'Harmonic Orbit';
+    imuToggle.textContent = 'Connect IMU Stream';
+    imuToggle.classList.remove('active');
+    imuStatus.textContent = 'IMU stream idle. Click to connect.';
+    externalConfidence = null;
+    externalTimestamp = null;
+    imuIntegrator = null;
+    if (!stopSynthetic) {
+      stopSynthetic = startSyntheticRotation(autoAngles, (timestamp) => pushRotationSnapshot(timestamp));
+    }
+    if (latestDynamics) {
+      updateStatus(latestDynamics);
+    }
+  }
+});
+
+function createRotationControls(
+  container: HTMLDivElement,
+  manualState: RotationAngles,
+  onChange: () => void
+): (combined: RotationAngles, manual: RotationAngles) => void {
+  const valueLabels = new Map<keyof RotationAngles, HTMLSpanElement>();
+
+  for (const key of SIX_PLANE_KEYS) {
+    const group = document.createElement('section');
+    group.className = 'control-group';
+
+    const title = document.createElement('label');
+    title.textContent = `${key.toUpperCase()} Plane`;
+    title.htmlFor = `rotation-${key}`;
+
+    const slider = document.createElement('input');
+    slider.type = 'range';
+    slider.min = '-3.14159';
+    slider.max = '3.14159';
+    slider.step = '0.01';
+    slider.value = manualState[key].toString();
+    slider.id = `rotation-${key}`;
+
+    const valueLabel = document.createElement('span');
+    valueLabel.style.fontSize = '0.8rem';
+    valueLabel.style.color = 'rgba(211,246,255,0.8)';
+    valueLabel.textContent = '0.00 rad';
+
+    slider.addEventListener('input', () => {
+      manualState[key] = Number(slider.value);
+      onChange();
+    });
+
+    group.appendChild(title);
+    group.appendChild(slider);
+    group.appendChild(valueLabel);
+    container.appendChild(group);
+
+    valueLabels.set(key, valueLabel);
+  }
+
+  return (combined: RotationAngles, manual: RotationAngles) => {
+    for (const key of SIX_PLANE_KEYS) {
+      const label = valueLabels.get(key);
+      if (!label) continue;
+      const total = combined[key];
+      const offset = manual[key];
+      label.textContent = `${total.toFixed(2)} rad (offset ${offset.toFixed(2)})`;
+    }
+  };
+}
+
+function startSyntheticRotation(autoState: RotationAngles, onUpdate: (timestamp: number) => void) {
+  const orbit = createHarmonicOrbit();
+  const startedAt = performance.now();
+  let running = true;
+  let frameHandle = 0;
+
+  const tick = () => {
+    if (!running) return;
+    const now = performance.now();
+    const elapsed = (now - startedAt) / 1000;
+    const orbitAngles = orbit(elapsed);
+
+    for (const plane of SIX_PLANE_KEYS) {
+      autoState[plane] = orbitAngles[plane];
+    }
+
+    onUpdate(now);
+    frameHandle = requestAnimationFrame(tick);
+  };
+  frameHandle = requestAnimationFrame(tick);
+
+  return () => {
+    running = false;
+    cancelAnimationFrame(frameHandle);
+  };
+}
+
+function updateStatus(dynamics: RotationDynamics) {
+  statusEl.textContent = `${statusBase} · source ${rotationSource} · energy ${(dynamics.energy * 100).toFixed(0)}% · chaos ${(dynamics.chaos * 100).toFixed(0)}%`;
+}
+
+function initializeProjectionControls() {
+  updateProjectionControlUi(projectionMode);
+  projectionDepthSlider.value = projectionControlValues[projectionMode].toString();
+}
+
+function updateProjectionControlUi(mode: ProjectionMode) {
+  switch (mode) {
+    case 'perspective':
+      projectionDepthLabel.textContent = 'Projection Depth';
+      projectionDepthSlider.min = '1';
+      projectionDepthSlider.max = '8';
+      projectionDepthSlider.step = '0.1';
+      break;
+    case 'stereographic':
+      projectionDepthLabel.textContent = 'Stereographic Scale';
+      projectionDepthSlider.min = '0.2';
+      projectionDepthSlider.max = '4';
+      projectionDepthSlider.step = '0.05';
+      break;
+    case 'orthographic':
+      projectionDepthLabel.textContent = 'Orthographic Scale';
+      projectionDepthSlider.min = '0.2';
+      projectionDepthSlider.max = '3';
+      projectionDepthSlider.step = '0.05';
+      break;
+  }
+}
+
+function createStyleIndicators(container: HTMLDivElement) {
+  const metrics: Array<{ key: keyof RotationDynamics; label: string }> = [
+    { key: 'energy', label: 'Energy Flux' },
+    { key: 'spatial', label: 'Spatial Flow' },
+    { key: 'hyperspatial', label: 'Hyperspatial Flow' },
+    { key: 'harmonic', label: 'Harmonic Phase' },
+    { key: 'chaos', label: 'Chaos Weave' }
+  ];
+
+  const elements = new Map<keyof RotationDynamics, { fill: HTMLSpanElement; value: HTMLSpanElement }>();
+  container.replaceChildren();
+
+  for (const metric of metrics) {
+    const row = document.createElement('div');
+    row.className = 'meter-row';
+
+    const label = document.createElement('span');
+    label.textContent = metric.label;
+    label.className = 'meter-label';
+
+    const meter = document.createElement('div');
+    meter.className = 'meter-bar';
+
+    const fill = document.createElement('span');
+    fill.className = 'meter-fill';
+    meter.appendChild(fill);
+
+    const value = document.createElement('span');
+    value.className = 'meter-value';
+    value.textContent = '0%';
+
+    row.appendChild(label);
+    row.appendChild(meter);
+    row.appendChild(value);
+    container.appendChild(row);
+
+    elements.set(metric.key, { fill, value });
+  }
+
+  return (dynamics: RotationDynamics) => {
+    for (const metric of metrics) {
+      const pair = elements.get(metric.key);
+      if (!pair) continue;
+      const value = Math.max(0, Math.min(1, dynamics[metric.key] as number));
+      pair.fill.style.width = `${(value * 100).toFixed(1)}%`;
+      pair.value.textContent = `${Math.round(value * 100)}%`;
+    }
+  };
+}

--- a/src/pipeline/geometryCatalog.ts
+++ b/src/pipeline/geometryCatalog.ts
@@ -1,0 +1,30 @@
+import { TesseractGeometry } from '../geometry/tesseract';
+import { TwentyFourCellGeometry } from '../geometry/twentyFourCell';
+import type { GeometryData, GeometryDescriptor } from '../geometry/types';
+
+export type GeometryId = 'tesseract' | 'twentyFourCell';
+
+const CATALOG: Record<GeometryId, GeometryDescriptor> = {
+  tesseract: {
+    id: 'tesseract',
+    name: 'Tesseract',
+    data: TesseractGeometry
+  },
+  twentyFourCell: {
+    id: 'twentyFourCell',
+    name: '24-Cell',
+    data: TwentyFourCellGeometry
+  }
+};
+
+export function listGeometries(): GeometryDescriptor[] {
+  return Object.values(CATALOG);
+}
+
+export function getGeometry(id: GeometryId): GeometryData {
+  const entry = CATALOG[id];
+  if (!entry) {
+    throw new Error(`Unknown geometry: ${id}`);
+  }
+  return entry.data;
+}

--- a/src/pipeline/imuStream.ts
+++ b/src/pipeline/imuStream.ts
@@ -1,0 +1,122 @@
+import type { ImuPacket } from '../ingestion/imuMapper';
+
+type StatusCallback = (status: string) => void;
+
+type PacketCallback = (packet: ImuPacket, dt: number) => void;
+
+export interface ImuStreamOptions {
+  url: string;
+  onPacket: PacketCallback;
+  onStatus?: StatusCallback;
+  reconnectIntervalMs?: number;
+}
+
+const DEFAULT_RECONNECT_MS = 2500;
+const FALLBACK_SAMPLE_DT = 1 / 200;
+
+export class ImuStream {
+  private socket: WebSocket | null = null;
+  private lastTimestamp: number | null = null;
+  private reconnectHandle: number | null = null;
+  private active = false;
+
+  constructor(private readonly options: ImuStreamOptions) {}
+
+  start() {
+    if (this.active) return;
+    this.active = true;
+    this.connect();
+  }
+
+  stop() {
+    this.active = false;
+    if (this.socket) {
+      this.socket.close();
+      this.socket = null;
+    }
+    if (this.reconnectHandle !== null) {
+      clearTimeout(this.reconnectHandle);
+      this.reconnectHandle = null;
+    }
+    this.lastTimestamp = null;
+  }
+
+  private connect() {
+    if (!this.active) return;
+    try {
+      this.reportStatus(`Connecting to ${this.options.url}…`);
+      const socket = new WebSocket(this.options.url);
+      this.socket = socket;
+
+      socket.addEventListener('open', () => {
+        this.reportStatus('IMU stream connected');
+        this.lastTimestamp = null;
+      });
+
+      socket.addEventListener('message', (event) => {
+        this.handleMessage(event.data);
+      });
+
+      socket.addEventListener('close', () => {
+        this.reportStatus('IMU stream closed');
+        this.scheduleReconnect();
+      });
+
+      socket.addEventListener('error', (event) => {
+        console.error('IMU stream error', event);
+        this.reportStatus('IMU stream error – retrying');
+      });
+    } catch (error) {
+      console.error('Failed to open IMU stream', error);
+      this.reportStatus('IMU stream unavailable');
+      this.scheduleReconnect();
+    }
+  }
+
+  private scheduleReconnect() {
+    if (!this.active) return;
+    if (this.reconnectHandle !== null) return;
+    const interval = this.options.reconnectIntervalMs ?? DEFAULT_RECONNECT_MS;
+    this.reconnectHandle = window.setTimeout(() => {
+      this.reconnectHandle = null;
+      this.connect();
+    }, interval);
+  }
+
+  private handleMessage(data: unknown) {
+    let packet: ImuPacket | null = null;
+    try {
+      packet = typeof data === 'string' ? (JSON.parse(data) as ImuPacket) : (data as ImuPacket);
+    } catch (error) {
+      console.warn('Invalid IMU payload', error);
+      return;
+    }
+
+    if (!packet || typeof packet.timestamp !== 'number') {
+      console.warn('IMU payload missing timestamp');
+      return;
+    }
+
+    const dt = this.computeDeltaSeconds(packet.timestamp);
+    this.options.onPacket(packet, dt);
+  }
+
+  private computeDeltaSeconds(timestampMs: number): number {
+    if (this.lastTimestamp === null) {
+      this.lastTimestamp = timestampMs;
+      return FALLBACK_SAMPLE_DT;
+    }
+    const delta = (timestampMs - this.lastTimestamp) / 1000;
+    this.lastTimestamp = timestampMs;
+    if (!Number.isFinite(delta) || delta <= 0) {
+      return FALLBACK_SAMPLE_DT;
+    }
+    return delta;
+  }
+
+  private reportStatus(message: string) {
+    if (this.options.onStatus) {
+      this.options.onStatus(message);
+    }
+  }
+}

--- a/src/pipeline/rotationBus.ts
+++ b/src/pipeline/rotationBus.ts
@@ -1,0 +1,34 @@
+import type { RotationSnapshot } from '../core/rotationUniforms';
+import type { RotationDynamics } from '../core/styleUniforms';
+import { ZERO_DYNAMICS } from '../core/styleUniforms';
+
+export interface RotationEvent {
+  snapshot: RotationSnapshot;
+  dynamics: RotationDynamics;
+}
+
+export type RotationListener = (event: RotationEvent) => void;
+
+export class RotationBus {
+  private listeners = new Set<RotationListener>();
+  private latest: RotationEvent | null = null;
+
+  push(snapshot: RotationSnapshot, dynamics: RotationDynamics) {
+    this.latest = { snapshot, dynamics };
+    for (const listener of this.listeners) {
+      listener(this.latest);
+    }
+  }
+
+  subscribe(listener: RotationListener): () => void {
+    this.listeners.add(listener);
+    if (this.latest) {
+      listener(this.latest);
+    }
+    return () => this.listeners.delete(listener);
+  }
+
+  getLatest(defaultValue: RotationSnapshot): RotationEvent {
+    return this.latest ?? { snapshot: defaultValue, dynamics: ZERO_DYNAMICS };
+  }
+}

--- a/src/utils/math.ts
+++ b/src/utils/math.ts
@@ -1,0 +1,5 @@
+export function clamp(value: number, min: number, max: number): number {
+  if (value < min) return min;
+  if (value > max) return max;
+  return value;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "strict": true,
+    "baseUrl": "./",
+    "types": ["vite/client"],
+    "lib": ["DOM", "DOM.Iterable", "ES2020"],
+    "allowJs": false,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["src"],
+  "references": []
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  build: {
+    sourcemap: true
+  }
+});


### PR DESCRIPTION
## Summary
- add a configurable rotation mode to HypercubeCore so dual-quaternion snapshots can drive the renderer
- extend the vertex shader to support quaternion-based rotation alongside the sequential six-plane path
- default the app to the dual-quaternion compositor when bootstrapping the main entry point

## Testing
- npm run test -- --run
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d4945a36308329891b2b6ade2660d6