### PR TITLE
Surface manifest freshness telemetry

### DIFF
--- a/docs/rebuild-log.md
+++ b/docs/rebuild-log.md
@@ -1,0 +1,134 @@
+# Rebuild Blueprint Progress Log
+
+This log captures the follow-on work after the “Implement staged rebuild blueprint” baseline. Each entry records what was added in this session and why that piece matters for the staged HypercubeCore MVP.
+
+## Session – Telemetry & Frame Capture Bring-Up
+
+### What changed
+- **WebGL frame capture** (`HypercubeCore.captureFrame`, `flipPixelsVertically`) – expose a deterministic pixel readback so downstream services can pull actual render output instead of placeholder pixels.
+- **Dataset export metrics** (`DatasetExportService`) – track pending queue depth, total encoded frames, and last export format while flushing frames through the PSP stream.
+- **Control-panel telemetry** (`index.html`, `main.ts`) – surface uniform upload/skipped counts and dataset export metrics next to the rotation controls, keeping the operator aware of buffer health.
+- **Synthetic capture wiring** (`main.ts`) – replace the stubbed 1×1 pixel export with real captures throttled by queue depth and broadcast them via `LocalPspStream`.
+
+### Why these pieces matter
+- The **frame capture path** proves that Stage 2 geometry uploads can feed Stage 4 dataset export without leaving the GPU pipeline—critical for PSP archival and ML consumers.
+- **Dataset metrics** let us validate the UniformSync queue contract (exactly one upload per frame) and ensure capture/export doesn’t fall behind during automated or sensor-driven runs.
+- **UI telemetry** provides immediate operator feedback: if skips rise or pending frames spike, we know to adjust ingestion cadence before confidence drops.
+- **Real PSP captures** mean every rotation snapshot now carries a verifiable visual, keeping replay harnesses and external extruments in sync with the actual render output.
+
+### Next checkpoints
+- Thread the capture path through the dataset exporter worker once the Web Worker harness lands (Stage 4).
+- Extend telemetry with rolling latency stats (sensor → uniform upload → capture) to satisfy Stage 6 performance budgets.
+
+## Session – Worker Export Harness & Latency Telemetry
+
+### What changed
+- **Dataset export worker** (`datasetWorker.ts`, `DatasetExportService`) – spin up a dedicated encoder worker when available, track per-frame encode latency, and retain the JSON fallback for deterministic Node/Vitest runs.
+- **Pipeline latency tracker** (`LatencyTracker`) – capture rolling averages/maxima for sensor→uniform, uniform→capture, and encode phases, wiring the telemetry into the control panel for real-time monitoring.
+- **UI telemetry expansion** (`index.html`, `main.ts`) – surface uniform/capture/encode latency readouts plus last export format so operators can correlate queue depth with timing budgets.
+
+### Why these pieces matter
+- The **worker harness** keeps Stage 4 PSP exports off the main thread, preventing encode spikes from starving animation or sensor ingestion.
+- **Latency telemetry** closes the Stage 6 gap by quantifying the end-to-end pipeline budget, highlighting regressions long before they impact HAOS orchestration or ML taps.
+- The **control-panel readouts** give immediate feedback during live sessions, making it easier to tune parserator gains or dataset flush cadence when pending frames creep up.
+
+### Next checkpoints
+- Promote the worker harness into a reusable Web Worker pool once Stage 5 inference taps start sharing GPU time.
+- Record sensor-to-export latency envelopes alongside encoded frames to feed Stage 6 performance regression tests.
+
+## Session – Sensor→Export Latency Envelopes
+
+### What changed
+- **Uniform upload callbacks** (`HypercubeCore.setUniformUploadListener`) – expose a hook after each std140 upload so the main loop can align capture and PSP export with the exact snapshot that reached the GPU.
+- **Capture-triggered exports** (`main.ts`) – throttle capture inside the uniform callback, record capture latency, and attach uniform/capture timings to every queued frame before PSP export.
+- **Encode annotations** (`DatasetExportService`) – persist encode-complete timestamps and total pipeline latency inside each frame’s metadata, regardless of whether encoding happens inline or via the worker.
+- **Latency-aware metadata** (`datasetTypes.ts`, tests) – formalise a `PipelineLatencyEnvelope` contract and cover the fallback/worker paths so regressions surface during CI.
+
+### Why these pieces matter
+- **Deterministic envelopes** ensure Stage 6 tooling can assert sensor→uniform→capture→encode budgets directly from dataset artifacts instead of relying on external logs.
+- **Render-synchronised capture** keeps PSP snapshots aligned with the rotation state actually presented to the viewer, avoiding off-by-one uniform artefacts in downstream training data.
+- **Test coverage** guards against future refactors dropping latency timestamps, giving the rebuild blueprint a verified telemetry contract to build upon.
+
+### Next checkpoints
+- Persist latency envelopes alongside dataset manifests so replay harnesses can compare live runs against recorded totals.
+- Expose histogram/percentile views of the envelope metrics in the control panel for Stage 6 operator dashboards.
+
+## Session – Dataset Manifest Persistence
+
+### What changed
+- **Dataset manifest builder** (`datasetManifest.ts`, tests) – generate deterministic asset names, retain per-frame latency envelopes, and compute aggregate statistics with optional rehydration from previous sessions.
+- **Local storage persistence** (`main.ts`) – hydrate the manifest on load, append entries as PSP exports flush, and guard persistence with error logging when storage is unavailable.
+- **Control-panel telemetry** (`index.html`, `main.ts`) – surface manifest frame counts and p95 latency so operators can monitor archival coverage alongside live export metrics.
+
+### Why these pieces matter
+- The **builder** gives Stage 4+ pipelines a deterministic manifest contract so downstream tooling can reconcile encoded assets with their latency envelopes and rotation snapshots.
+- **Persistence** means operators can stop and resume sessions without losing manifest continuity, satisfying the rebuild blueprint’s requirement for deterministic dataset bookkeeping.
+- The **UI telemetry** closes the loop by exposing archival health directly in the control panel, enabling quick validation that latency percentiles stay within Stage 6 performance budgets.
+
+### Next checkpoints
+- Add manifest export/download affordances so recorded sessions can be archived or shared outside the browser sandbox.
+- Thread manifest statistics into the rebuild telemetry loom once percentile visualisations ship in Stage 6.
+
+## Session – Manifest Export & Archive Controls
+
+### What changed
+- **Manifest filename helper** (`createManifestDownloadName`) – normalises manifest IDs and stamps the latest update time to produce portable, deterministic archive names.
+- **Control-panel download action** (`index.html`, `main.ts`) – adds a dedicated button that serialises the current manifest, disables itself when empty, and streams a JSON download for archival.
+- **Test coverage** (`datasetManifest.test.ts`) – freezes system time to assert download filenames stay deterministic, preventing regressions in the archive contract.
+
+### Why these pieces matter
+- **Deterministic filenames** simplify reconciliation between local archives and persisted manifests, letting operators match downloads to on-device sessions at a glance.
+- **Inline download control** removes the need for devtools hacks when exporting manifests, ensuring Stage 4 dataset work can be shared or backed up immediately after capture.
+- **Tests** guarantee that future refactors keep filenames stable, protecting downstream automation that expects timestamped manifest artefacts.
+
+### Next checkpoints
+- Surface manifest last-updated timestamps directly in the control panel to signal when new frames are ready for export.
+- Bundle PSP frame batches with the manifest download so a single action captures both metadata and imagery for offline review.
+
+## Session – Parserator Calibration Controls
+
+### What changed
+- **Runtime mapping updates** (`parserator.ts`) – allow parserator instances to swap plane-mapping profiles and raise/lower their confidence floor without re-instantiation, keeping calibration live during sessions.
+- **Preprocessor lifecycle** (`parserator.ts`) – return disposal handles when registering preprocessors so temporary filters (e.g., gravity isolation) can be removed cleanly.
+- **Validation tests** (`parserator.test.ts`) – cover preprocessor ordering, profile switching, gravity isolation, and dynamic confidence floors to lock in the new behaviour.
+
+### Why these pieces matter
+- Live **profile switching** supports the rebuild plan’s Stage 3 parserator service, letting operators test alternate IMU mappings or external “extrument” adapters mid-run.
+- **Confidence floor tuning** keeps the rotation bus reliable when sensor noise changes, ensuring downstream uniform queues maintain minimum certainty without restarting the pipeline.
+- **Disposable preprocessors** simplify adaptive filtering—temporary smoothing or isolation filters can be toggled as telemetry warrants.
+- The **test suite** guards the calibration APIs so future refactors keep parserator tooling deterministic and composable for rebuild checkpoints.
+
+### Next checkpoints
+- Surface active profile metadata in the control panel and expose quick toggles for common calibration profiles.
+- Persist custom confidence floors and preprocessor stacks alongside dataset manifests so replay harnesses reproduce exact ingestion conditions.
+
+## Session – Parserator Console & Ingestion Persistence
+
+### What changed
+- **Control panel telemetry** (`index.html`, `main.ts`) – surfaced the active parserator profile, confidence floor, and enabled preprocessors with live selectors for quick calibration during capture sessions.
+- **Profile registry expansion** (`profiles.ts`, tests) – added high-gain and smoothing presets plus lookup utilities so UI controls and automation can target named profiles.
+- **Manifest ingestion metadata** (`datasetManifest.ts`, tests) – persisted the active profile, confidence floor, and preprocessor stack inside dataset manifests, keeping capture conditions reproducible across sessions.
+- **Parserator introspection** (`parserator.ts`, tests) – exposed profile/confidence getters and deterministic preprocessor IDs so the UI and manifest writer can track live calibration state.
+
+### Why these pieces matter
+- **Inline visibility** keeps operators aware of the ingestion stack feeding the rotation bus, enabling rapid comparisons between presets without diving into code.
+- **Persisted calibration** ensures replay harnesses and downstream ML consumers can rehydrate the exact parserator configuration alongside captured frames, satisfying the rebuild blueprint’s determinism goals.
+- **Named profiles and preprocessors** provide a stable contract for future extrument adapters and parserator microservices to request or advertise calibration presets.
+
+### Next checkpoints
+- Stream parserator events into the telemetry loom so profile swaps and confidence adjustments appear in historical timelines.
+- Allow manifests to capture per-frame confidence histograms, extending ingestion analytics into the dataset export pipeline.
+
+## Session – Manifest Freshness Telemetry
+
+### What changed
+- **Control-panel timestamp** (`index.html`, `main.ts`) – added a live “Manifest updated” readout that tracks the last manifest write alongside frame counts and latency percentiles.
+- **Relative time formatter** (`main.ts`) – renders recent updates in milliseconds/seconds and falls back to localised wall-clock time for longer gaps, so operators always see meaningful recency info.
+
+### Why these pieces matter
+- **Freshness telemetry** signals exactly when dataset archives last changed, helping operators confirm capture activity without digging into downloads or local storage.
+- **Adaptive formatting** keeps the telemetry legible during both rapid capture bursts and longer idle windows, aligning with the rebuild plan’s operator-focused diagnostics.
+
+### Next checkpoints
+- Surface ingest-config update times alongside manifest freshness so calibration tweaks remain auditable.
+- Feed manifest timestamps into the telemetry loom once session timelines are in place, enabling historical plots of capture cadence.

--- a/index.html
+++ b/index.html
@@ -43,13 +43,90 @@
         letter-spacing: 0.08em;
         color: #9edcff;
       }
+      .telemetry {
+        border-top: 1px solid rgba(86, 180, 252, 0.2);
+        padding-top: 12px;
+        margin-top: 12px;
+        gap: 8px;
+      }
+      .telemetry-row {
+        display: flex;
+        justify-content: space-between;
+        font-size: 0.75rem;
+        color: rgba(211, 246, 255, 0.85);
+      }
+      .telemetry-row span:first-child {
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        color: rgba(144, 202, 249, 0.85);
+      }
       .control-group input[type="range"] {
         width: 100%;
+      }
+      button {
+        padding: 10px 12px;
+        border: 1px solid rgba(127, 210, 255, 0.4);
+        border-radius: 6px;
+        background: linear-gradient(135deg, rgba(23, 74, 120, 0.8), rgba(15, 36, 62, 0.8));
+        color: #e7faff;
+        font-size: 0.8rem;
+        font-weight: 600;
+        letter-spacing: 0.04em;
+        cursor: pointer;
+        transition: background 0.2s ease, transform 0.2s ease;
+      }
+      button:hover:not(:disabled) {
+        background: linear-gradient(135deg, rgba(33, 104, 168, 0.9), rgba(20, 50, 86, 0.9));
+        transform: translateY(-1px);
+      }
+      button:disabled {
+        opacity: 0.45;
+        cursor: default;
       }
       canvas {
         width: 100%;
         height: 100%;
         display: block;
+      }
+      #extrument-payload {
+        font-family: "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+        display: inline-block;
+        max-width: 180px;
+        text-align: right;
+        line-height: 1.3;
+        word-break: break-word;
+      }
+      #parserator-preprocessor-controls {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+      }
+      .parserator-toggle {
+        display: flex;
+        gap: 10px;
+        align-items: flex-start;
+        background: rgba(18, 32, 52, 0.35);
+        border: 1px solid rgba(86, 180, 252, 0.16);
+        border-radius: 6px;
+        padding: 8px;
+      }
+      .parserator-toggle input[type="checkbox"] {
+        margin-top: 4px;
+      }
+      .parserator-toggle span {
+        font-size: 0.78rem;
+        color: rgba(211, 246, 255, 0.9);
+        font-weight: 600;
+        display: block;
+      }
+      .parserator-toggle small {
+        display: block;
+        margin-top: 2px;
+        font-size: 0.68rem;
+        color: rgba(158, 220, 255, 0.7);
+      }
+      #parserator-confidence-value {
+        font-variant-numeric: tabular-nums;
       }
       #status {
         font-size: 0.75rem;
@@ -79,6 +156,87 @@
         <section class="control-group">
           <label for="lineWidth">Line Width</label>
           <input id="lineWidth" type="range" min="1" max="6" step="0.5" value="2" />
+        </section>
+        <section id="telemetry" class="control-group telemetry">
+          <div class="telemetry-row">
+            <span>Uniform uploads</span>
+            <span id="uniform-uploads">0</span>
+          </div>
+          <div class="telemetry-row">
+            <span>Uniform skips</span>
+            <span id="uniform-skips">0</span>
+          </div>
+          <div class="telemetry-row">
+            <span>Uniform latency</span>
+            <span id="uniform-latency">0 ms</span>
+          </div>
+          <div class="telemetry-row">
+            <span>Capture latency</span>
+            <span id="capture-latency">0 ms</span>
+          </div>
+          <div class="telemetry-row">
+            <span>Pending frames</span>
+            <span id="dataset-pending">0</span>
+          </div>
+          <div class="telemetry-row">
+            <span>Encoded frames</span>
+            <span id="dataset-total">0</span>
+          </div>
+          <div class="telemetry-row">
+            <span>Encode latency</span>
+            <span id="encode-latency">0 ms</span>
+          </div>
+          <div class="telemetry-row">
+            <span>Last format</span>
+            <span id="dataset-format">–</span>
+          </div>
+          <div class="telemetry-row">
+            <span>Manifest frames</span>
+            <span id="manifest-frames">0</span>
+          </div>
+          <div class="telemetry-row">
+            <span>Manifest p95</span>
+            <span id="manifest-p95">–</span>
+          </div>
+          <div class="telemetry-row">
+            <span>Manifest updated</span>
+            <span id="manifest-updated">–</span>
+          </div>
+          <button id="manifest-download">Download manifest</button>
+        </section>
+        <section id="parserator" class="control-group telemetry">
+          <div class="telemetry-row">
+            <span>Active profile</span>
+            <span id="parserator-profile-name">Default IMU</span>
+          </div>
+          <div class="telemetry-row">
+            <span>Confidence floor</span>
+            <span id="parserator-confidence-value">0.60</span>
+          </div>
+          <div class="telemetry-row">
+            <span>Preprocessors</span>
+            <span id="parserator-preprocessors">–</span>
+          </div>
+          <label for="parserator-profile-select">Mapping profile</label>
+          <select id="parserator-profile-select"></select>
+          <label for="parserator-confidence-input">Confidence floor</label>
+          <input id="parserator-confidence-input" type="range" min="0" max="1" step="0.01" value="0.60" />
+          <div id="parserator-preprocessor-controls"></div>
+        </section>
+        <section id="extrument" class="control-group telemetry">
+          <div class="telemetry-row">
+            <span>Extrument</span>
+            <span id="extrument-status">Idle</span>
+          </div>
+          <div class="telemetry-row">
+            <span>Outputs</span>
+            <span id="extrument-output">–</span>
+          </div>
+          <div class="telemetry-row">
+            <span>Last frame</span>
+            <span id="extrument-payload">–</span>
+          </div>
+          <button id="extrument-connect">Connect MIDI Extrument</button>
         </section>
       </aside>
       <canvas id="gl-canvas"></canvas>

--- a/src/core/frameUtils.test.ts
+++ b/src/core/frameUtils.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { flipPixelsVertically } from './frameUtils';
+
+function createCheckerboard(width: number, height: number): Uint8Array {
+  const data = new Uint8Array(width * height * 4);
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      const index = (y * width + x) * 4;
+      const on = (x + y) % 2 === 0;
+      data[index + 0] = on ? 255 : 0;
+      data[index + 1] = on ? 128 : 0;
+      data[index + 2] = on ? 64 : 0;
+      data[index + 3] = 255;
+    }
+  }
+  return data;
+}
+
+describe('flipPixelsVertically', () => {
+  it('returns a vertically flipped copy of the pixel buffer', () => {
+    const width = 2;
+    const height = 3;
+    const source = createCheckerboard(width, height);
+    const flipped = flipPixelsVertically(width, height, source);
+
+    // Top row in source should become bottom row in flipped
+    const sourceTop = Array.from(source.slice(0, width * 4));
+    const flippedBottom = Array.from(flipped.slice((height - 1) * width * 4));
+    expect(flippedBottom).toEqual(sourceTop);
+
+    // Bottom row in source should become top row in flipped
+    const sourceBottom = Array.from(source.slice((height - 1) * width * 4));
+    const flippedTop = Array.from(flipped.slice(0, width * 4));
+    expect(flippedTop).toEqual(sourceBottom);
+  });
+});

--- a/src/core/frameUtils.ts
+++ b/src/core/frameUtils.ts
@@ -1,0 +1,14 @@
+export function flipPixelsVertically(
+  width: number,
+  height: number,
+  source: Uint8Array | Uint8ClampedArray
+): Uint8ClampedArray {
+  const bytesPerRow = width * 4;
+  const flipped = new Uint8ClampedArray(source.length);
+  for (let row = 0; row < height; row++) {
+    const srcStart = row * bytesPerRow;
+    const destStart = (height - 1 - row) * bytesPerRow;
+    flipped.set(source.subarray(srcStart, srcStart + bytesPerRow), destStart);
+  }
+  return flipped;
+}

--- a/src/core/rotationUniforms.test.ts
+++ b/src/core/rotationUniforms.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { rotationEnergy, ZERO_ROTATION, type RotationAngles } from './rotationUniforms';
+
+describe('rotationEnergy', () => {
+  it('is zero for the neutral rotation', () => {
+    expect(rotationEnergy(ZERO_ROTATION)).toBe(0);
+  });
+
+  it('sums the absolute magnitude of every plane', () => {
+    const angles: RotationAngles = {
+      xy: Math.PI / 4,
+      xz: -Math.PI / 6,
+      yz: 0,
+      xw: -0.5,
+      yw: 0.75,
+      zw: -1.25
+    };
+
+    const expected =
+      Math.abs(angles.xy) +
+      Math.abs(angles.xz) +
+      Math.abs(angles.yz) +
+      Math.abs(angles.xw) +
+      Math.abs(angles.yw) +
+      Math.abs(angles.zw);
+
+    expect(rotationEnergy(angles)).toBeCloseTo(expected, 1e-10);
+  });
+
+  it('does not mutate the input angles', () => {
+    const angles: RotationAngles = {
+      xy: 0.3,
+      xz: -0.2,
+      yz: 0.1,
+      xw: -0.4,
+      yw: 0.05,
+      zw: -0.6
+    };
+
+    const copy = { ...angles };
+    rotationEnergy(angles);
+    expect(angles).toStrictEqual(copy);
+  });
+});

--- a/src/core/rotationUniforms.ts
+++ b/src/core/rotationUniforms.ts
@@ -65,3 +65,14 @@ export const ZERO_ROTATION: RotationAngles = {
   yw: 0,
   zw: 0
 };
+
+export function rotationEnergy(angles: RotationAngles): number {
+  return (
+    Math.abs(angles.xy) +
+    Math.abs(angles.xz) +
+    Math.abs(angles.yz) +
+    Math.abs(angles.xw) +
+    Math.abs(angles.yw) +
+    Math.abs(angles.zw)
+  );
+}

--- a/src/core/sixPlaneOrbit.test.ts
+++ b/src/core/sixPlaneOrbit.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { createHarmonicOrbit, SIX_PLANE_KEYS } from './sixPlaneOrbit';
+import { createHarmonicOrbit, createRotationLoom, SIX_PLANE_KEYS } from './sixPlaneOrbit';
 
 describe('six plane harmonic orbit', () => {
   it('produces bounded angles for each plane', () => {
@@ -18,5 +18,17 @@ describe('six plane harmonic orbit', () => {
     for (const plane of SIX_PLANE_KEYS) {
       expect(Math.abs(late[plane] - early[plane])).toBeLessThan(0.5);
     }
+  });
+
+  it('records rotation loom samples with bounded length', () => {
+    const orbit = createHarmonicOrbit();
+    const loom = createRotationLoom(orbit, 10);
+    let lastEnergy = 0;
+    for (let i = 0; i < 50; i++) {
+      const samples = loom(i * 0.1);
+      lastEnergy = samples[samples.length - 1]?.energy ?? 0;
+      expect(samples.length).toBeLessThanOrEqual(10);
+    }
+    expect(lastEnergy).toBeGreaterThan(0);
   });
 });

--- a/src/core/sixPlaneOrbit.ts
+++ b/src/core/sixPlaneOrbit.ts
@@ -1,4 +1,4 @@
-import type { RotationAngles } from './rotationUniforms';
+import { rotationEnergy, type RotationAngles } from './rotationUniforms';
 
 const TAU = Math.PI * 2;
 export const SIX_PLANE_KEYS: ReadonlyArray<keyof RotationAngles> = ['xy', 'xz', 'yz', 'xw', 'yw', 'zw'];
@@ -16,6 +16,12 @@ export interface OrbitSpec {
   planes: OrbitPlane[];
   coupling?: number;
   hyperCoupling?: number;
+}
+
+export interface LoomSample {
+  time: number;
+  energy: number;
+  angles: RotationAngles;
 }
 
 const GOLDEN_RATIO = (1 + Math.sqrt(5)) / 2;
@@ -79,5 +85,25 @@ export function createHarmonicOrbit(spec: OrbitSpec = defaultSpec()): (timeSecon
     }
 
     return angles;
+  };
+}
+
+export function createRotationLoom(
+  orbit: (timeSeconds: number) => RotationAngles,
+  length = 240
+): (timeSeconds: number) => LoomSample[] {
+  const samples: LoomSample[] = [];
+  return (timeSeconds: number) => {
+    const angles = orbit(timeSeconds);
+    const energy = rotationEnergy(angles);
+    samples.push({
+      time: timeSeconds,
+      energy,
+      angles: { ...angles }
+    });
+    if (samples.length > length) {
+      samples.shift();
+    }
+    return samples.slice();
   };
 }

--- a/src/core/uberShaderBuilder.test.ts
+++ b/src/core/uberShaderBuilder.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { UberShaderBuilder } from './uberShaderBuilder';
+
+describe('UberShaderBuilder', () => {
+  it('concatenates modules with headers', () => {
+    const builder = new UberShaderBuilder();
+    builder.addModule({
+      name: 'geometry',
+      header: '#define ENABLE_GEOMETRY',
+      body: 'vec4 loadGeometry() { return vec4(0.0); }'
+    });
+    builder.addModule({
+      name: 'projection',
+      body: 'vec3 project(vec4 v) { return v.xyz; }'
+    });
+
+    const result = builder.build();
+    expect(result).toContain('#define ENABLE_GEOMETRY');
+    expect(result).toContain('module: projection');
+  });
+});

--- a/src/core/uberShaderBuilder.ts
+++ b/src/core/uberShaderBuilder.ts
@@ -1,0 +1,19 @@
+export interface ShaderModule {
+  name: string;
+  header?: string;
+  body: string;
+}
+
+export class UberShaderBuilder {
+  private readonly modules: ShaderModule[] = [];
+
+  addModule(module: ShaderModule) {
+    this.modules.push(module);
+  }
+
+  build(): string {
+    const header = this.modules.map(module => module.header ?? '').join('\n');
+    const body = this.modules.map(module => `// module: ${module.name}\n${module.body}`).join('\n\n');
+    return `${header}\n${body}`.trim();
+  }
+}

--- a/src/core/uniformSyncQueue.test.ts
+++ b/src/core/uniformSyncQueue.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+import { UniformSyncQueue } from './uniformSyncQueue';
+
+describe('UniformSyncQueue', () => {
+  it('only exposes the latest snapshot per frame', () => {
+    const queue = new UniformSyncQueue();
+    queue.enqueue({ xy: 0.1, xz: 0.2, yz: 0.3, xw: 0, yw: 0, zw: 0, timestamp: 1, confidence: 1 });
+    queue.enqueue({ xy: 0.5, xz: 0.6, yz: 0.7, xw: 0, yw: 0, zw: 0, timestamp: 2, confidence: 1 });
+    const snapshot = queue.consume();
+    expect(snapshot?.xy).toBeCloseTo(0.5);
+    expect(queue.consume()).toBeNull();
+  });
+});

--- a/src/core/uniformSyncQueue.ts
+++ b/src/core/uniformSyncQueue.ts
@@ -1,0 +1,47 @@
+import type { RotationSnapshot } from './rotationUniforms';
+
+export interface UniformSyncMetrics {
+  enqueued: number;
+  uploads: number;
+  skipped: number;
+  lastUploadTime: number;
+  lastSnapshotTimestamp: number;
+  lastUploadLatency: number;
+}
+
+export class UniformSyncQueue {
+  private pending: RotationSnapshot | null = null;
+  private metrics: UniformSyncMetrics = {
+    enqueued: 0,
+    uploads: 0,
+    skipped: 0,
+    lastUploadTime: performance.now(),
+    lastSnapshotTimestamp: 0,
+    lastUploadLatency: 0
+  };
+
+  enqueue(snapshot: RotationSnapshot) {
+    this.metrics.enqueued += 1;
+    if (this.pending) {
+      this.metrics.skipped += 1;
+    }
+    this.pending = { ...snapshot };
+  }
+
+  consume(): RotationSnapshot | null {
+    if (!this.pending) {
+      return null;
+    }
+    const snapshot = this.pending;
+    this.pending = null;
+    this.metrics.uploads += 1;
+    this.metrics.lastUploadTime = performance.now();
+    this.metrics.lastSnapshotTimestamp = snapshot.timestamp;
+    this.metrics.lastUploadLatency = Math.max(0, this.metrics.lastUploadTime - snapshot.timestamp);
+    return snapshot;
+  }
+
+  getMetrics(): UniformSyncMetrics {
+    return { ...this.metrics };
+  }
+}

--- a/src/geometry/geometryTopology.test.ts
+++ b/src/geometry/geometryTopology.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { listGeometries } from '../pipeline/geometryCatalog';
+
+function eulerCharacteristic(topology: { vertices: number; edges: number; faces: number; cells: number }): number {
+  return topology.vertices - topology.edges + topology.faces - topology.cells;
+}
+
+describe('geometry topologies', () => {
+  const geometries = listGeometries();
+
+  it('exposes all required topologies', () => {
+    expect(geometries.length).toBeGreaterThan(0);
+    for (const descriptor of geometries) {
+      expect(descriptor.data.topology.vertices).toBeGreaterThan(0);
+      expect(descriptor.data.topology.edges).toBeGreaterThan(0);
+    }
+  });
+
+  it('has Euler characteristic of zero for regular polychora', () => {
+    for (const descriptor of geometries) {
+      const chi = eulerCharacteristic(descriptor.data.topology);
+      expect(Math.abs(chi)).toBeLessThanOrEqual(1e-9);
+    }
+  });
+});

--- a/src/geometry/sixHundredCell.ts
+++ b/src/geometry/sixHundredCell.ts
@@ -1,0 +1,125 @@
+import { LINE_DRAW_MODE, type GeometryData } from './types';
+
+const PHI = (1 + Math.sqrt(5)) / 2;
+const INV_PHI = 1 / PHI;
+
+function createSixHundredCell(): GeometryData {
+  const vertices: number[][] = [];
+  const seen = new Set<string>();
+
+  function addVertex(v: number[]) {
+    const key = v.map(value => value.toFixed(6)).join(',');
+    if (!seen.has(key)) {
+      seen.add(key);
+      vertices.push(v);
+    }
+  }
+
+  // 16 hypercube vertices (±1/2, ±1/2, ±1/2, ±1/2)
+  for (const sx of [-0.5, 0.5]) {
+    for (const sy of [-0.5, 0.5]) {
+      for (const sz of [-0.5, 0.5]) {
+        for (const sw of [-0.5, 0.5]) {
+          addVertex([sx, sy, sz, sw]);
+        }
+      }
+    }
+  }
+
+  // 8 cross-polytope vertices (±1, 0, 0, 0)
+  for (let axis = 0; axis < 4; axis++) {
+    for (const sign of [-1, 1]) {
+      const v = [0, 0, 0, 0];
+      v[axis] = sign;
+      addVertex(v);
+    }
+  }
+
+  // 96 permutations of (0, ±1/2, ±phi/2, ±1/(2phi))
+  const base = [0, 0.5, PHI / 2, INV_PHI / 2];
+  const permutations = generatePermutations([0, 1, 2, 3]);
+
+  for (const perm of permutations) {
+    const components = perm.map(index => base[index]);
+    const nonZeroIndices = components
+      .map((value, index) => (Math.abs(value) > 1e-6 ? index : -1))
+      .filter(index => index >= 0);
+
+    const signCombos = 1 << nonZeroIndices.length;
+    for (let mask = 0; mask < signCombos; mask++) {
+      const candidate = components.slice();
+      let signParity = 1;
+      for (let bit = 0; bit < nonZeroIndices.length; bit++) {
+        const idx = nonZeroIndices[bit];
+        const sign = (mask & (1 << bit)) ? -1 : 1;
+        candidate[idx] *= sign;
+        signParity *= sign;
+      }
+
+      // Only accept configurations with even sign parity to enforce 96 vertices
+      if (signParity > 0) {
+        addVertex(candidate);
+      }
+    }
+  }
+
+  if (vertices.length !== 120) {
+    throw new Error(`600-cell vertex generation failed (expected 120, got ${vertices.length})`);
+  }
+
+  const candidates: Array<{ a: number; b: number; distance: number }> = [];
+  for (let i = 0; i < vertices.length; i++) {
+    for (let j = i + 1; j < vertices.length; j++) {
+      candidates.push({ a: i, b: j, distance: distanceSquared(vertices[i], vertices[j]) });
+    }
+  }
+
+  candidates.sort((a, b) => a.distance - b.distance);
+
+  const indices: number[] = [];
+  for (let k = 0; k < 720; k++) {
+    const edge = candidates[k];
+    indices.push(edge.a, edge.b);
+  }
+
+  if (indices.length / 2 !== 720) {
+    throw new Error(`600-cell edge generation failed (expected 720, got ${indices.length / 2})`);
+  }
+
+  return {
+    positions: new Float32Array(vertices.flat()),
+    indices: new Uint16Array(indices),
+    drawMode: LINE_DRAW_MODE,
+    vertexStride: 4,
+    topology: {
+      vertices: 120,
+      edges: 720,
+      faces: 1200,
+      cells: 600
+    }
+  };
+}
+
+function generatePermutations(indices: number[]): number[][] {
+  if (indices.length === 1) return [indices.slice()];
+  const permutations: number[][] = [];
+  for (let i = 0; i < indices.length; i++) {
+    const [current] = indices.splice(i, 1);
+    for (const rest of generatePermutations(indices)) {
+      permutations.push([current, ...rest]);
+    }
+    indices.splice(i, 0, current);
+  }
+  return permutations;
+}
+
+function distanceSquared(a: number[], b: number[]): number {
+  let sum = 0;
+  for (let i = 0; i < 4; i++) {
+    const d = a[i] - b[i];
+    sum += d * d;
+  }
+  return sum;
+}
+
+export const SixHundredCellGeometry = createSixHundredCell();

--- a/src/geometry/tesseract.ts
+++ b/src/geometry/tesseract.ts
@@ -1,4 +1,4 @@
-import type { GeometryData } from './types';
+import { LINE_DRAW_MODE, type GeometryData } from './types';
 
 function createTesseractGeometry(): GeometryData {
   const vertices: number[][] = [];
@@ -35,8 +35,14 @@ function createTesseractGeometry(): GeometryData {
   return {
     positions: new Float32Array(vertices.flat()),
     indices: new Uint16Array(indices),
-    drawMode: WebGL2RenderingContext.LINES,
-    vertexStride: 4
+    drawMode: LINE_DRAW_MODE,
+    vertexStride: 4,
+    topology: {
+      vertices: vertices.length,
+      edges: indices.length / 2,
+      faces: 24,
+      cells: 8
+    }
   };
 }
 

--- a/src/geometry/twentyFourCell.ts
+++ b/src/geometry/twentyFourCell.ts
@@ -1,4 +1,4 @@
-import type { GeometryData } from './types';
+import { LINE_DRAW_MODE, type GeometryData } from './types';
 
 function createTwentyFourCell(): GeometryData {
   const vertices: number[][] = [];
@@ -37,8 +37,14 @@ function createTwentyFourCell(): GeometryData {
   return {
     positions: new Float32Array(vertices.flat()),
     indices: new Uint16Array(indices),
-    drawMode: WebGL2RenderingContext.LINES,
-    vertexStride: 4
+    drawMode: LINE_DRAW_MODE,
+    vertexStride: 4,
+    topology: {
+      vertices: vertices.length,
+      edges: indices.length / 2,
+      faces: 96,
+      cells: 24
+    }
   };
 }
 

--- a/src/geometry/types.ts
+++ b/src/geometry/types.ts
@@ -1,8 +1,16 @@
+export interface GeometryTopology {
+  vertices: number;
+  edges: number;
+  faces: number;
+  cells: number;
+}
+
 export interface GeometryData {
   positions: Float32Array;
   indices: Uint16Array;
   drawMode: number;
   vertexStride: number;
+  topology: GeometryTopology;
 }
 
 export interface GeometryDescriptor {
@@ -10,3 +18,5 @@ export interface GeometryDescriptor {
   name: string;
   data: GeometryData;
 }
+
+export const LINE_DRAW_MODE = 0x0001;

--- a/src/ingestion/extrumentHub.test.ts
+++ b/src/ingestion/extrumentHub.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { RotationSnapshot } from '../core/rotationUniforms';
+import { ExtrumentHub, normalizeSnapshot, describeSnapshot, type ExtrumentAdapter } from './extrumentHub';
+
+const baseSnapshot: RotationSnapshot = {
+  xy: Math.PI / 4,
+  xz: -Math.PI / 6,
+  yz: Math.PI / 8,
+  xw: -Math.PI / 3,
+  yw: 0.2,
+  zw: -0.15,
+  timestamp: 42,
+  confidence: 0.9
+};
+
+describe('normalizeSnapshot', () => {
+  it('normalizes angles into 0..1 range with default clamp', () => {
+    const normalized = normalizeSnapshot(baseSnapshot);
+    expect(normalized.planes.xy).toBeCloseTo(0.5 + 0.5 * (baseSnapshot.xy / Math.PI), 5);
+    expect(normalized.planes.xz).toBeLessThan(0.5);
+    expect(normalized.timestamp).toBe(baseSnapshot.timestamp);
+    expect(normalized.raw.xy).toBe(baseSnapshot.xy);
+  });
+
+  it('respects unclamped mode', () => {
+    const snapshot = { ...baseSnapshot, xy: Math.PI * 2 };
+    const normalized = normalizeSnapshot(snapshot, { clamp: false });
+    expect(normalized.planes.xy).toBeGreaterThan(1);
+  });
+
+  it('reports magnitude as mean absolute angle', () => {
+    const normalized = normalizeSnapshot(baseSnapshot);
+    const manual =
+      (Math.abs(baseSnapshot.xy) +
+        Math.abs(baseSnapshot.xz) +
+        Math.abs(baseSnapshot.yz) +
+        Math.abs(baseSnapshot.xw) +
+        Math.abs(baseSnapshot.yw) +
+        Math.abs(baseSnapshot.zw)) /
+      6;
+    expect(normalized.magnitude).toBeCloseTo(manual, 6);
+  });
+
+  it('describes snapshot with concise summary', () => {
+    const normalized = normalizeSnapshot(baseSnapshot);
+    const summary = describeSnapshot(normalized);
+    expect(summary).toContain('σ=');
+    expect(summary).toContain('xy:');
+  });
+});
+
+describe('ExtrumentHub', () => {
+  const createAdapter = (id: string): ExtrumentAdapter<number> => ({
+    id,
+    connect: vi.fn().mockResolvedValue(undefined),
+    disconnect: vi.fn().mockResolvedValue(undefined),
+    send: vi.fn().mockResolvedValue(undefined)
+  });
+
+  it('registers adapters and broadcasts transformed payloads', async () => {
+    const adapter = createAdapter('alpha');
+    const hub = new ExtrumentHub<number>({
+      transform: (snapshot) => Math.round(snapshot.xy * 100)
+    });
+    hub.register(adapter);
+    await hub.connect('alpha');
+    await hub.broadcast(baseSnapshot);
+    expect(adapter.send).toHaveBeenCalledWith(Math.round(baseSnapshot.xy * 100));
+  });
+
+  it('disconnects adapters that throw during send and surfaces errors', async () => {
+    const adapter = createAdapter('beta');
+    const error = new Error('failed');
+    (adapter.send as ReturnType<typeof vi.fn>).mockRejectedValueOnce(error);
+    const onError = vi.fn();
+    const hub = new ExtrumentHub<number>({ transform: () => 0, onError });
+    hub.register(adapter);
+    await hub.connect('beta');
+    await hub.broadcast(baseSnapshot);
+    expect(onError).toHaveBeenCalledWith(error, adapter);
+  });
+
+  it('throws when connecting unknown adapters', async () => {
+    const hub = new ExtrumentHub();
+    await expect(hub.connect('missing')).rejects.toThrow('Unknown adapter');
+  });
+});

--- a/src/ingestion/extrumentHub.ts
+++ b/src/ingestion/extrumentHub.ts
@@ -1,0 +1,141 @@
+import type { RotationSnapshot } from '../core/rotationUniforms';
+import { SIX_PLANE_KEYS } from '../core/sixPlaneOrbit';
+
+type PlaneKey = (typeof SIX_PLANE_KEYS)[number];
+
+export interface ExtrumentAdapter<TPayload = RotationSnapshot> {
+  readonly id: string;
+  connect(): Promise<void> | void;
+  disconnect(): Promise<void> | void;
+  send(payload: TPayload): Promise<void> | void;
+  isConnected?(): boolean;
+}
+
+export interface ExtrumentHubOptions<TPayload> {
+  transform?: (snapshot: RotationSnapshot) => TPayload;
+  onError?: (error: unknown, adapter: ExtrumentAdapter<TPayload>) => void;
+}
+
+interface AdapterState<TPayload> {
+  adapter: ExtrumentAdapter<TPayload>;
+  connected: boolean;
+}
+
+export class ExtrumentHub<TPayload = RotationSnapshot> {
+  private readonly adapters = new Map<string, AdapterState<TPayload>>();
+  private readonly transform: (snapshot: RotationSnapshot) => TPayload;
+  private readonly onError?: (error: unknown, adapter: ExtrumentAdapter<TPayload>) => void;
+
+  constructor(options: ExtrumentHubOptions<TPayload> = {}) {
+    this.transform = options.transform ?? ((snapshot) => snapshot as unknown as TPayload);
+    this.onError = options.onError;
+  }
+
+  register(adapter: ExtrumentAdapter<TPayload>): () => void {
+    if (this.adapters.has(adapter.id)) {
+      throw new Error(`Adapter with id ${adapter.id} is already registered`);
+    }
+    this.adapters.set(adapter.id, { adapter, connected: false });
+    return () => {
+      const entry = this.adapters.get(adapter.id);
+      if (!entry) return;
+      if (entry.connected) {
+        void entry.adapter.disconnect();
+      }
+      this.adapters.delete(adapter.id);
+    };
+  }
+
+  async connect(id: string): Promise<void> {
+    const entry = this.adapters.get(id);
+    if (!entry) {
+      throw new Error(`Unknown adapter ${id}`);
+    }
+    if (entry.connected) return;
+    await entry.adapter.connect();
+    entry.connected = entry.adapter.isConnected ? entry.adapter.isConnected() ?? true : true;
+  }
+
+  async disconnect(id: string): Promise<void> {
+    const entry = this.adapters.get(id);
+    if (!entry) return;
+    if (!entry.connected) return;
+    await entry.adapter.disconnect();
+    entry.connected = entry.adapter.isConnected ? entry.adapter.isConnected() ?? false : false;
+  }
+
+  async broadcast(snapshot: RotationSnapshot): Promise<void> {
+    if (this.adapters.size === 0) return;
+    const payload = this.transform(snapshot);
+    await this.broadcastPayload(payload);
+  }
+
+  async broadcastPayload(payload: TPayload): Promise<void> {
+    if (this.adapters.size === 0) return;
+    for (const state of this.adapters.values()) {
+      if (!state.connected) continue;
+      try {
+        await state.adapter.send(payload);
+      } catch (error) {
+        state.connected = state.adapter.isConnected ? state.adapter.isConnected() ?? false : false;
+        if (this.onError) {
+          this.onError(error, state.adapter);
+        }
+      }
+    }
+  }
+
+  listAdapters(): Array<{ id: string; connected: boolean }> {
+    return Array.from(this.adapters.values()).map(({ adapter, connected }) => ({
+      id: adapter.id,
+      connected
+    }));
+  }
+}
+
+export interface NormalizedSnapshot {
+  timestamp: number;
+  confidence: number;
+  magnitude: number;
+  planes: Record<PlaneKey, number>;
+  raw: RotationSnapshot;
+}
+
+export interface NormalizeOptions {
+  range?: number;
+  clamp?: boolean;
+}
+
+export function normalizeSnapshot(snapshot: RotationSnapshot, options: NormalizeOptions = {}): NormalizedSnapshot {
+  const range = options.range ?? Math.PI;
+  const clamp = options.clamp ?? true;
+  const planes = {} as Record<PlaneKey, number>;
+  let magnitude = 0;
+
+  for (const plane of SIX_PLANE_KEYS) {
+    const value = snapshot[plane];
+    magnitude += Math.abs(value);
+    let normalized = range === 0 ? 0 : value / range;
+    if (clamp) {
+      normalized = Math.min(1, Math.max(-1, normalized));
+    }
+    planes[plane] = normalized * 0.5 + 0.5;
+  }
+
+  magnitude /= SIX_PLANE_KEYS.length;
+
+  return {
+    timestamp: snapshot.timestamp,
+    confidence: snapshot.confidence,
+    magnitude,
+    planes,
+    raw: { ...snapshot }
+  };
+}
+
+export function describeSnapshot(snapshot: NormalizedSnapshot): string {
+  const planeSummary = SIX_PLANE_KEYS
+    .map((plane) => `${plane}:${snapshot.planes[plane].toFixed(2)}`)
+    .join(' ');
+  return `σ=${snapshot.magnitude.toFixed(2)} · c=${snapshot.confidence.toFixed(2)} · ${planeSummary}`;
+}

--- a/src/ingestion/midiExtrument.test.ts
+++ b/src/ingestion/midiExtrument.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi } from 'vitest';
+import { MidiExtrumentAdapter, discoverMidiAdapters, type MidiOutputLike } from './midiExtrument';
+import { type NormalizedSnapshot } from './extrumentHub';
+
+const snapshot: NormalizedSnapshot = {
+  timestamp: 100,
+  confidence: 0.8,
+  magnitude: 0.5,
+  planes: { xy: 0.1, xz: 0.2, yz: 0.3, xw: 0.4, yw: 0.5, zw: 0.6 },
+  raw: {
+    xy: 0,
+    xz: 0,
+    yz: 0,
+    xw: 0,
+    yw: 0,
+    zw: 0,
+    timestamp: 100,
+    confidence: 0.8
+  }
+};
+
+describe('MidiExtrumentAdapter', () => {
+  it('sends control change messages for each plane', async () => {
+    const sent: number[][] = [];
+    const output: MidiOutputLike = {
+      id: 'out-1',
+      send: (message) => {
+        sent.push(message);
+      }
+    };
+    const adapter = new MidiExtrumentAdapter({ output });
+    await adapter.connect();
+    await adapter.send(snapshot);
+    expect(sent).toHaveLength(8); // 6 planes + magnitude + confidence
+    expect(sent[0][1]).toBe(20);
+    expect(sent[0][2]).toBeGreaterThanOrEqual(0);
+    expect(adapter.label).toBe('out-1');
+  });
+});
+
+describe('discoverMidiAdapters', () => {
+  it('selects the first output by default', async () => {
+    const outputs: MidiOutputLike[] = [
+      { id: 'first', send: vi.fn() },
+      { id: 'second', send: vi.fn() }
+    ];
+    const adapters = await discoverMidiAdapters({
+      accessFactory: async () => ({ outputs })
+    });
+    expect(adapters).toHaveLength(1);
+    expect(adapters[0].id).toBe('midi:first');
+  });
+
+  it('returns empty list when selector rejects outputs', async () => {
+    const adapters = await discoverMidiAdapters({
+      accessFactory: async () => ({ outputs: [] }),
+      selectOutput: () => undefined
+    });
+    expect(adapters).toHaveLength(0);
+  });
+});

--- a/src/ingestion/midiExtrument.ts
+++ b/src/ingestion/midiExtrument.ts
@@ -1,0 +1,109 @@
+import { SIX_PLANE_KEYS } from '../core/sixPlaneOrbit';
+import type { ExtrumentAdapter, NormalizedSnapshot } from './extrumentHub';
+
+export interface MidiOutputLike {
+  id: string;
+  name?: string;
+  send(message: number[], timestamp?: number): void;
+}
+
+export interface MidiExtrumentOptions {
+  output: MidiOutputLike;
+  channel?: number;
+  controlChangeMap?: number[];
+  magnitudeCc?: number;
+  confidenceCc?: number;
+}
+
+function clampMidi(value: number): number {
+  if (Number.isNaN(value)) return 0;
+  return Math.min(127, Math.max(0, Math.round(value)));
+}
+
+function toMidiValue(normalized: number): number {
+  return clampMidi(normalized * 127);
+}
+
+export class MidiExtrumentAdapter implements ExtrumentAdapter<NormalizedSnapshot> {
+  readonly id: string;
+  readonly label: string;
+  private readonly output: MidiOutputLike;
+  private readonly channel: number;
+  private readonly ccMap: number[];
+  private readonly magnitudeCc?: number;
+  private readonly confidenceCc?: number;
+  private connected = false;
+
+  constructor(options: MidiExtrumentOptions) {
+    this.output = options.output;
+    this.id = `midi:${options.output.id}`;
+    this.label = options.output.name ?? options.output.id;
+    this.channel = Math.min(15, Math.max(0, Math.floor(options.channel ?? 0)));
+    this.ccMap = options.controlChangeMap ?? [20, 21, 22, 23, 24, 25];
+    this.magnitudeCc = options.magnitudeCc ?? 26;
+    this.confidenceCc = options.confidenceCc ?? 27;
+  }
+
+  isConnected(): boolean {
+    return this.connected;
+  }
+
+  async connect(): Promise<void> {
+    this.connected = true;
+  }
+
+  async disconnect(): Promise<void> {
+    this.connected = false;
+  }
+
+  async send(snapshot: NormalizedSnapshot): Promise<void> {
+    if (!this.connected) return;
+    const status = 0xb0 | this.channel;
+    const values = SIX_PLANE_KEYS.map((plane) => toMidiValue(snapshot.planes[plane]));
+    for (let i = 0; i < Math.min(this.ccMap.length, values.length); i++) {
+      this.output.send([status, this.ccMap[i], values[i]], snapshot.timestamp);
+    }
+    if (this.magnitudeCc !== undefined) {
+      this.output.send([status, this.magnitudeCc, clampMidi(snapshot.magnitude * 127)], snapshot.timestamp);
+    }
+    if (this.confidenceCc !== undefined) {
+      this.output.send([status, this.confidenceCc, clampMidi(snapshot.confidence * 127)], snapshot.timestamp);
+    }
+  }
+}
+
+type MidiAccessLike = {
+  outputs: Iterable<MidiOutputLike> | Map<string, MidiOutputLike>;
+};
+
+type MidiAccessFactory = () => Promise<MidiAccessLike>;
+
+function resolveOutputs(collection: MidiAccessLike['outputs']): MidiOutputLike[] {
+  if (collection instanceof Map) {
+    return Array.from(collection.values());
+  }
+  if (Symbol.iterator in Object(collection)) {
+    return Array.from(collection as Iterable<MidiOutputLike>);
+  }
+  return [];
+}
+
+export interface MidiDiscoveryOptions {
+  accessFactory: MidiAccessFactory;
+  selectOutput?: (outputs: MidiOutputLike[]) => MidiOutputLike | undefined;
+}
+
+export async function discoverMidiAdapters(
+  options: MidiDiscoveryOptions
+): Promise<MidiExtrumentAdapter[]> {
+  const access = await options.accessFactory();
+  const outputs = resolveOutputs(access.outputs);
+  const select = options.selectOutput ?? ((list: MidiOutputLike[]) => list[0]);
+  const chosen = select(outputs);
+  if (!chosen) return [];
+  return [
+    new MidiExtrumentAdapter({
+      output: chosen
+    })
+  ];
+}

--- a/src/ingestion/parserator.test.ts
+++ b/src/ingestion/parserator.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ImuPacket } from './imuMapper';
+import { Parserator, gravityIsolation } from './parserator';
+import type { PlaneMappingProfile } from './profiles';
+
+const basePacket: ImuPacket = {
+  timestamp: 1_000,
+  gyro: [0.5, -0.25, 0.75],
+  accel: [0.1, 0.2, 0.3],
+  confidence: 0.2
+};
+
+const identityProfile: PlaneMappingProfile = {
+  id: 'identity',
+  name: 'Identity passthrough',
+  spatial: [
+    { axis: 'x', plane: 'xy', gain: 1, smoothing: 0 },
+    { axis: 'y', plane: 'xz', gain: 1, smoothing: 0 },
+    { axis: 'z', plane: 'yz', gain: 1, smoothing: 0 }
+  ],
+  hyperspatial: [
+    { axis: 'x', plane: 'xw', gain: 1, smoothing: 0 },
+    { axis: 'y', plane: 'yw', gain: 1, smoothing: 0 },
+    { axis: 'z', plane: 'zw', gain: 1, smoothing: 0 }
+  ]
+};
+
+describe('Parserator', () => {
+  it('applies preprocessors and enforces the confidence floor', () => {
+    const parserator = new Parserator({ profile: identityProfile, confidenceFloor: 0.6 });
+    const preprocessor = vi.fn((packet: ImuPacket) => ({
+      ...packet,
+      gyro: [1, 2, 3]
+    }));
+    parserator.registerPreprocessor(preprocessor, { id: 'mock-preprocessor' });
+
+    const listener = vi.fn();
+    parserator.onSnapshot(listener);
+
+    parserator.ingest(basePacket);
+
+    expect(preprocessor).toHaveBeenCalled();
+    expect(listener).toHaveBeenCalledTimes(1);
+    const snapshot = listener.mock.calls[0][0];
+    expect(snapshot.xy).toBeCloseTo(1, 6);
+    expect(snapshot.xz).toBeCloseTo(2, 6);
+    expect(snapshot.yz).toBeCloseTo(3, 6);
+    expect(snapshot.confidence).toBeCloseTo(0.6, 6);
+  });
+
+  it('supports unregistering preprocessors via disposer', () => {
+    const parserator = new Parserator({ profile: identityProfile });
+    const preprocessor = vi.fn((packet: ImuPacket) => packet);
+    const registration = parserator.registerPreprocessor(preprocessor, { id: 'disposable' });
+
+    parserator.ingest({ ...basePacket, timestamp: 2_000 });
+    registration.dispose();
+    parserator.ingest({ ...basePacket, timestamp: 3_000 });
+
+    expect(preprocessor).toHaveBeenCalledTimes(1);
+    expect(parserator.listPreprocessors()).not.toContain('disposable');
+  });
+
+  it('switches mapping profiles at runtime', () => {
+    const parserator = new Parserator({ profile: identityProfile });
+    const listener = vi.fn();
+    parserator.onSnapshot(listener);
+
+    parserator.ingest({ ...basePacket, timestamp: 4_000 });
+
+    const remappedProfile: PlaneMappingProfile = {
+      id: 'remap',
+      name: 'Remapped planes',
+      spatial: [
+        { axis: 'x', plane: 'yz', gain: 2, smoothing: 0 },
+        { axis: 'y', plane: 'xy', gain: 0.5, smoothing: 0 },
+        { axis: 'z', plane: 'xz', gain: 1.5, smoothing: 0 }
+      ],
+      hyperspatial: identityProfile.hyperspatial
+    };
+
+    parserator.setProfile(remappedProfile);
+    listener.mockClear();
+
+    const packet: ImuPacket = {
+      timestamp: 5_000,
+      gyro: [0.4, -0.6, 0.2],
+      accel: [0.3, 0.1, 0.5]
+    };
+
+    parserator.ingest(packet);
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    const snapshot = listener.mock.calls[0][0];
+    expect(snapshot.yz).toBeCloseTo(0.8, 6);
+    expect(snapshot.xy).toBeCloseTo(-0.3, 6);
+    expect(snapshot.xz).toBeCloseTo(0.3, 6);
+  });
+
+  it('allows updating the confidence floor dynamically', () => {
+    const parserator = new Parserator({ profile: identityProfile, confidenceFloor: 0.1 });
+    const listener = vi.fn();
+    parserator.onSnapshot(listener);
+
+    parserator.ingest({ ...basePacket, confidence: 0.05, timestamp: 6_000 });
+    parserator.setConfidenceFloor(0.9);
+    parserator.ingest({ ...basePacket, confidence: 0.2, timestamp: 7_000 });
+
+    const [, second] = listener.mock.calls;
+    expect(second[0].confidence).toBeCloseTo(0.9, 6);
+  });
+
+  it('composes preprocessors with gravity isolation helper', () => {
+    const parserator = new Parserator({ profile: identityProfile });
+    const listener = vi.fn();
+    parserator.onSnapshot(listener);
+
+    parserator.registerPreprocessor(gravityIsolation(0.5), { id: 'gravity' });
+
+    const packet: ImuPacket = {
+      timestamp: 8_000,
+      gyro: [0, 0, 0],
+      accel: [0, 0, 1]
+    };
+
+    parserator.ingest(packet);
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    const snapshot = listener.mock.calls[0][0];
+    expect(snapshot.xw).toBeCloseTo(0, 6);
+    expect(snapshot.yw).toBeCloseTo(0, 6);
+    expect(snapshot.zw).toBeCloseTo(0.5, 6);
+    expect(parserator.listPreprocessors()).toContain('gravity');
+  });
+
+  it('reports current profile metadata and confidence floor', () => {
+    const parserator = new Parserator({ profile: identityProfile, confidenceFloor: 0.42 });
+    expect(parserator.getProfile().id).toBe('identity');
+    expect(parserator.getConfidenceFloor()).toBeCloseTo(0.42);
+
+    const alternate: PlaneMappingProfile = {
+      id: 'alternate',
+      name: 'Alternate Profile',
+      spatial: identityProfile.spatial,
+      hyperspatial: identityProfile.hyperspatial
+    };
+
+    parserator.setProfile(alternate);
+    parserator.setConfidenceFloor(0.73);
+
+    expect(parserator.getProfile().id).toBe('alternate');
+    expect(parserator.getConfidenceFloor()).toBeCloseTo(0.73);
+  });
+});

--- a/src/ingestion/parserator.ts
+++ b/src/ingestion/parserator.ts
@@ -1,0 +1,183 @@
+import { mapImuPacket, type ImuPacket } from './imuMapper';
+import type { RotationSnapshot } from '../core/rotationUniforms';
+import type { PlaneMappingProfile } from './profiles';
+import { DEFAULT_PROFILE } from './profiles';
+
+export type Preprocessor = (packet: ImuPacket) => ImuPacket;
+export type SnapshotListener = (snapshot: RotationSnapshot) => void;
+
+export interface PreprocessorOptions {
+  id?: string;
+}
+
+export interface PreprocessorRegistration {
+  id: string;
+  dispose: () => void;
+}
+
+export interface ParseratorOptions {
+  profile?: PlaneMappingProfile;
+  confidenceFloor?: number;
+}
+
+export class Parserator {
+  private preprocessors: Array<{ id: string; handler: Preprocessor }> = [];
+  private listeners = new Set<SnapshotListener>();
+  private lastTimestamp = 0;
+  private profile: PlaneMappingProfile;
+  private confidenceFloor: number;
+  private preprocessorCounter = 0;
+
+  constructor(options: ParseratorOptions = {}) {
+    this.profile = options.profile ?? DEFAULT_PROFILE;
+    this.confidenceFloor = options.confidenceFloor ?? 0.6;
+  }
+
+  registerPreprocessor(fn: Preprocessor, options: PreprocessorOptions = {}): PreprocessorRegistration {
+    const id = options.id ?? `preprocessor-${++this.preprocessorCounter}`;
+    this.preprocessors.push({ id, handler: fn });
+    return {
+      id,
+      dispose: () => {
+        const index = this.preprocessors.findIndex(entry => entry.id === id);
+        if (index >= 0) {
+          this.preprocessors.splice(index, 1);
+        }
+      }
+    };
+  }
+
+  onSnapshot(listener: SnapshotListener) {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  setProfile(profile: PlaneMappingProfile): void {
+    this.profile = profile;
+  }
+
+  setConfidenceFloor(confidence: number): void {
+    this.confidenceFloor = confidence;
+  }
+
+  getProfile(): PlaneMappingProfile {
+    return this.profile;
+  }
+
+  getConfidenceFloor(): number {
+    return this.confidenceFloor;
+  }
+
+  listPreprocessors(): string[] {
+    return this.preprocessors.map(entry => entry.id);
+  }
+
+  ingest(packet: ImuPacket) {
+    let processed = packet;
+    for (const entry of this.preprocessors) {
+      processed = entry.handler(processed);
+    }
+
+    const dt = this.computeDelta(processed.timestamp);
+    const snapshot = mapImuPacket(processed, dt);
+    snapshot.confidence = Math.max(snapshot.confidence, this.confidenceFloor);
+    this.applyProfile(snapshot, processed);
+
+    for (const listener of this.listeners) {
+      listener({ ...snapshot });
+    }
+  }
+
+  private computeDelta(timestamp: number): number {
+    if (this.lastTimestamp === 0) {
+      this.lastTimestamp = timestamp;
+      return 0.016;
+    }
+    const dt = Math.max(1e-3, (timestamp - this.lastTimestamp) / 1000);
+    this.lastTimestamp = timestamp;
+    return dt;
+  }
+
+  private applyProfile(snapshot: RotationSnapshot, packet: ImuPacket) {
+    const axisIndex = { x: 0, y: 1, z: 2 } as const;
+
+    for (const channel of this.profile.spatial) {
+      const index = axisIndex[channel.axis];
+      const value = packet.gyro[index] * channel.gain;
+      snapshot[channel.plane] = this.applySmoothing(snapshot[channel.plane], value, channel.smoothing);
+      if (channel.clamp !== undefined) {
+        snapshot[channel.plane] = clamp(snapshot[channel.plane], -channel.clamp, channel.clamp);
+      }
+    }
+
+    for (const channel of this.profile.hyperspatial) {
+      const index = axisIndex[channel.axis];
+      const value = packet.accel[index] * channel.gain;
+      snapshot[channel.plane] = this.applySmoothing(snapshot[channel.plane], value, channel.smoothing);
+      if (channel.clamp !== undefined) {
+        snapshot[channel.plane] = clamp(snapshot[channel.plane], -channel.clamp, channel.clamp);
+      }
+    }
+  }
+
+  private applySmoothing(current: number, incoming: number, smoothing = 0): number {
+    if (smoothing <= 0) return incoming;
+    return current * smoothing + incoming * (1 - smoothing);
+  }
+}
+
+export function lowPassGyro(cutoff: number): Preprocessor {
+  let last: ImuPacket | null = null;
+  return packet => {
+    if (!last) {
+      last = packet;
+      return packet;
+    }
+    const blend = Math.exp(-cutoff * Math.max(1e-3, (packet.timestamp - last.timestamp) / 1000));
+    const gyro: [number, number, number] = [0, 0, 0];
+    for (let i = 0; i < 3; i++) {
+      gyro[i] = blend * last.gyro[i] + (1 - blend) * packet.gyro[i];
+    }
+    last = { ...packet, gyro };
+    return last;
+  };
+}
+
+export function gravityIsolation(strength: number): Preprocessor {
+  return packet => {
+    const [ax, ay, az] = packet.accel;
+    const magnitude = Math.max(Math.hypot(ax, ay, az), 1e-5);
+    const normalized: [number, number, number] = [ax / magnitude, ay / magnitude, az / magnitude];
+    return { ...packet, accel: normalized.map(value => value * strength) as [number, number, number] };
+  };
+}
+
+export function featureWindow(windowSize: number): Preprocessor {
+  const window: ImuPacket[] = [];
+  return packet => {
+    window.push(packet);
+    if (window.length > windowSize) window.shift();
+    const averaged = averagePackets(window);
+    return { ...packet, gyro: averaged.gyro, accel: averaged.accel };
+  };
+}
+
+function averagePackets(samples: ImuPacket[]): { gyro: [number, number, number]; accel: [number, number, number] } {
+  const gyro: [number, number, number] = [0, 0, 0];
+  const accel: [number, number, number] = [0, 0, 0];
+  for (const sample of samples) {
+    for (let i = 0; i < 3; i++) {
+      gyro[i] += sample.gyro[i];
+      accel[i] += sample.accel[i];
+    }
+  }
+  for (let i = 0; i < 3; i++) {
+    gyro[i] /= samples.length;
+    accel[i] /= samples.length;
+  }
+  return { gyro, accel };
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}

--- a/src/ingestion/profiles.test.ts
+++ b/src/ingestion/profiles.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { AVAILABLE_PROFILES, DEFAULT_PROFILE, getProfileById } from './profiles';
+
+describe('profiles', () => {
+  it('exposes the default profile in the registry', () => {
+    const profile = getProfileById(DEFAULT_PROFILE.id);
+    expect(profile?.name).toBe(DEFAULT_PROFILE.name);
+  });
+
+  it('returns undefined for unknown profile ids', () => {
+    expect(getProfileById('missing-profile')).toBeUndefined();
+  });
+
+  it('lists profiles in a deterministic order', () => {
+    const ids = AVAILABLE_PROFILES.map(profile => profile.id);
+    const sorted = [...ids].sort();
+    expect(ids).toEqual(sorted);
+  });
+});

--- a/src/ingestion/profiles.ts
+++ b/src/ingestion/profiles.ts
@@ -1,0 +1,73 @@
+import type { RotationAngles } from '../core/rotationUniforms';
+
+export type RotationPlane = keyof RotationAngles;
+
+export interface MappingChannel {
+  axis: 'x' | 'y' | 'z';
+  plane: RotationPlane;
+  gain: number;
+  clamp?: number;
+  smoothing?: number;
+}
+
+export interface PlaneMappingProfile {
+  id: string;
+  name: string;
+  spatial: MappingChannel[];
+  hyperspatial: MappingChannel[];
+}
+
+export const DEFAULT_PROFILE: PlaneMappingProfile = {
+  id: 'default-imu',
+  name: 'Default IMU',
+  spatial: [
+    { axis: 'x', plane: 'yz', gain: 1.0, smoothing: 0.1 },
+    { axis: 'y', plane: 'xz', gain: 0.95, smoothing: 0.1 },
+    { axis: 'z', plane: 'xy', gain: 0.9, smoothing: 0.1 }
+  ],
+  hyperspatial: [
+    { axis: 'x', plane: 'xw', gain: 0.35, smoothing: 0.2 },
+    { axis: 'y', plane: 'yw', gain: 0.35, smoothing: 0.2 },
+    { axis: 'z', plane: 'zw', gain: 0.35, smoothing: 0.2 }
+  ]
+};
+
+export const SMOOTHING_PROFILE: PlaneMappingProfile = {
+  id: 'smooth-orbit',
+  name: 'Smooth Orbit',
+  spatial: [
+    { axis: 'x', plane: 'yz', gain: 0.85, smoothing: 0.45 },
+    { axis: 'y', plane: 'xz', gain: 0.8, smoothing: 0.45 },
+    { axis: 'z', plane: 'xy', gain: 0.82, smoothing: 0.45 }
+  ],
+  hyperspatial: [
+    { axis: 'x', plane: 'xw', gain: 0.28, smoothing: 0.55 },
+    { axis: 'y', plane: 'yw', gain: 0.28, smoothing: 0.55 },
+    { axis: 'z', plane: 'zw', gain: 0.28, smoothing: 0.55 }
+  ]
+};
+
+export const HIGH_GAIN_PROFILE: PlaneMappingProfile = {
+  id: 'high-gain-imu',
+  name: 'High Gain',
+  spatial: [
+    { axis: 'x', plane: 'yz', gain: 1.35, clamp: 2.8, smoothing: 0.08 },
+    { axis: 'y', plane: 'xz', gain: 1.25, clamp: 2.8, smoothing: 0.08 },
+    { axis: 'z', plane: 'xy', gain: 1.2, clamp: 2.6, smoothing: 0.08 }
+  ],
+  hyperspatial: [
+    { axis: 'x', plane: 'xw', gain: 0.48, clamp: 1.4, smoothing: 0.2 },
+    { axis: 'y', plane: 'yw', gain: 0.48, clamp: 1.4, smoothing: 0.2 },
+    { axis: 'z', plane: 'zw', gain: 0.48, clamp: 1.4, smoothing: 0.2 }
+  ]
+};
+
+export const AVAILABLE_PROFILES: PlaneMappingProfile[] = [
+  DEFAULT_PROFILE,
+  HIGH_GAIN_PROFILE,
+  SMOOTHING_PROFILE
+];
+
+export function getProfileById(id: string): PlaneMappingProfile | undefined {
+  return AVAILABLE_PROFILES.find(profile => profile.id === id);
+}

--- a/src/ingestion/replayHarness.ts
+++ b/src/ingestion/replayHarness.ts
@@ -1,0 +1,24 @@
+import type { ImuPacket } from './imuMapper';
+import { Parserator, type ParseratorOptions } from './parserator';
+
+export interface ReplayOptions extends ParseratorOptions {
+  tickIntervalMs?: number;
+}
+
+export function replayDataset(packets: ImuPacket[], options: ReplayOptions = {}) {
+  const parserator = new Parserator(options);
+  const interval = options.tickIntervalMs ?? 16;
+
+  let index = 0;
+  function dispatchNext() {
+    if (index >= packets.length) return;
+    parserator.ingest(packets[index]);
+    index += 1;
+    if (index < packets.length) {
+      setTimeout(dispatchNext, interval);
+    }
+  }
+
+  dispatchNext();
+  return parserator;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,40 @@
 import { HypercubeCore } from './core/hypercubeCore';
-import { ZERO_ROTATION, type RotationAngles, type RotationSnapshot } from './core/rotationUniforms';
+import {
+  rotationEnergy,
+  ZERO_ROTATION,
+  type RotationAngles,
+  type RotationSnapshot
+} from './core/rotationUniforms';
 import { createHarmonicOrbit, SIX_PLANE_KEYS } from './core/sixPlaneOrbit';
-import { getGeometry, type GeometryId } from './pipeline/geometryCatalog';
+import { type GeometryId } from './pipeline/geometryCatalog';
 import { RotationBus } from './pipeline/rotationBus';
+import { GeometryController } from './pipeline/geometryController';
+import { DatasetExportService } from './pipeline/datasetExport';
+import {
+  DatasetManifestBuilder,
+  DATASET_MANIFEST_STORAGE_KEY,
+  createManifestDownloadName,
+  type DatasetManifest
+} from './pipeline/datasetManifest';
+import { LocalPspStream } from './pipeline/pspStream';
+import { FocusDirector } from './pipeline/focusDirector';
+import { LatencyTracker } from './pipeline/latencyTracker';
+import {
+  ExtrumentHub,
+  normalizeSnapshot,
+  describeSnapshot,
+  type NormalizedSnapshot
+} from './ingestion/extrumentHub';
+import { discoverMidiAdapters } from './ingestion/midiExtrument';
+import {
+  Parserator,
+  gravityIsolation,
+  lowPassGyro,
+  featureWindow,
+  type PreprocessorRegistration,
+  type Preprocessor
+} from './ingestion/parserator';
+import { AVAILABLE_PROFILES, DEFAULT_PROFILE, getProfileById } from './ingestion/profiles';
 
 const canvas = document.getElementById('gl-canvas') as HTMLCanvasElement;
 const statusEl = document.getElementById('status') as HTMLParagraphElement;
@@ -10,8 +42,59 @@ const geometrySelect = document.getElementById('geometry') as HTMLSelectElement;
 const projectionDepthSlider = document.getElementById('projectionDepth') as HTMLInputElement;
 const lineWidthSlider = document.getElementById('lineWidth') as HTMLInputElement;
 const rotationControlsContainer = document.getElementById('rotation-controls') as HTMLDivElement;
+const uniformUploadsEl = document.getElementById('uniform-uploads') as HTMLSpanElement;
+const uniformSkipsEl = document.getElementById('uniform-skips') as HTMLSpanElement;
+const datasetPendingEl = document.getElementById('dataset-pending') as HTMLSpanElement;
+const datasetTotalEl = document.getElementById('dataset-total') as HTMLSpanElement;
+const uniformLatencyEl = document.getElementById('uniform-latency') as HTMLSpanElement;
+const captureLatencyEl = document.getElementById('capture-latency') as HTMLSpanElement;
+const encodeLatencyEl = document.getElementById('encode-latency') as HTMLSpanElement;
+const datasetFormatEl = document.getElementById('dataset-format') as HTMLSpanElement;
+const manifestFramesEl = document.getElementById('manifest-frames') as HTMLSpanElement;
+const manifestP95El = document.getElementById('manifest-p95') as HTMLSpanElement;
+const manifestUpdatedEl = document.getElementById('manifest-updated') as HTMLSpanElement;
+const manifestDownloadButton = document.getElementById('manifest-download') as HTMLButtonElement;
+const parseratorProfileNameEl = document.getElementById('parserator-profile-name') as HTMLSpanElement;
+const parseratorProfileSelect = document.getElementById('parserator-profile-select') as HTMLSelectElement;
+const parseratorConfidenceValueEl = document.getElementById('parserator-confidence-value') as HTMLSpanElement;
+const parseratorConfidenceInput = document.getElementById('parserator-confidence-input') as HTMLInputElement;
+const parseratorPreprocessorsEl = document.getElementById('parserator-preprocessors') as HTMLSpanElement;
+const parseratorPreprocessorContainer = document.getElementById('parserator-preprocessor-controls') as HTMLDivElement;
+const extrumentStatusEl = document.getElementById('extrument-status') as HTMLSpanElement;
+const extrumentOutputEl = document.getElementById('extrument-output') as HTMLSpanElement;
+const extrumentPayloadEl = document.getElementById('extrument-payload') as HTMLSpanElement;
+const extrumentConnectButton = document.getElementById('extrument-connect') as HTMLButtonElement;
 
-if (!canvas || !statusEl || !geometrySelect || !projectionDepthSlider || !lineWidthSlider || !rotationControlsContainer) {
+if (
+  !canvas ||
+  !statusEl ||
+  !geometrySelect ||
+  !projectionDepthSlider ||
+  !lineWidthSlider ||
+  !rotationControlsContainer ||
+  !uniformUploadsEl ||
+  !uniformSkipsEl ||
+  !datasetPendingEl ||
+  !datasetTotalEl ||
+  !uniformLatencyEl ||
+  !captureLatencyEl ||
+  !encodeLatencyEl ||
+  !datasetFormatEl ||
+  !manifestFramesEl ||
+  !manifestP95El ||
+  !manifestUpdatedEl ||
+  !manifestDownloadButton ||
+  !parseratorProfileNameEl ||
+  !parseratorProfileSelect ||
+  !parseratorConfidenceValueEl ||
+  !parseratorConfidenceInput ||
+  !parseratorPreprocessorsEl ||
+  !parseratorPreprocessorContainer ||
+  !extrumentStatusEl ||
+  !extrumentOutputEl ||
+  !extrumentPayloadEl ||
+  !extrumentConnectButton
+) {
   throw new Error('Required DOM nodes are missing');
 }
 
@@ -20,8 +103,124 @@ const core = new HypercubeCore(canvas, {
   lineWidth: Number(lineWidthSlider.value)
 });
 
+const geometryController = new GeometryController(core);
 const rotationBus = new RotationBus();
 rotationBus.subscribe(snapshot => core.updateRotation(snapshot));
+const latencyTracker = new LatencyTracker();
+const datasetExport = new DatasetExportService({
+  onLatencySample: latency => latencyTracker.recordEncode(latency)
+});
+
+let persistedManifest: DatasetManifest | undefined;
+try {
+  if (typeof localStorage !== 'undefined') {
+    const raw = localStorage.getItem(DATASET_MANIFEST_STORAGE_KEY);
+    if (raw) {
+      persistedManifest = JSON.parse(raw) as DatasetManifest;
+    }
+  }
+} catch (error) {
+  console.warn('Failed to load dataset manifest', error);
+}
+
+const manifestBuilder = new DatasetManifestBuilder({ hydrateFrom: persistedManifest });
+const pspStream = new LocalPspStream();
+const focusDirector = new FocusDirector(geometryController, rotationBus, { fallbackGeometry: 'tesseract' });
+const MAX_PENDING_FRAMES = 48;
+
+const extrumentHub = new ExtrumentHub<NormalizedSnapshot>({
+  transform: normalizeSnapshot,
+  onError: (error, adapter) => {
+    console.warn('Extrument adapter error', error);
+    extrumentStatusEl.textContent = `Error · ${adapter.id}`;
+    extrumentConnected = false;
+    extrumentConnectButton.disabled = false;
+  }
+});
+const extrumentAdapterLabels = new Map<string, string>();
+let extrumentConnected = false;
+const extrumentDisconnectors: Array<() => void> = [];
+
+const parserator = new Parserator();
+
+type PreprocessorOption = {
+  id: string;
+  label: string;
+  description: string;
+  factory: () => Preprocessor;
+};
+
+const PREPROCESSOR_OPTIONS: PreprocessorOption[] = [
+  {
+    id: 'low-pass',
+    label: 'Low-pass gyro',
+    description: 'Smooths gyro spikes with an adaptive exponential filter.',
+    factory: () => lowPassGyro(6)
+  },
+  {
+    id: 'gravity',
+    label: 'Gravity isolation',
+    description: 'Normalises acceleration vectors to isolate orientation cues.',
+    factory: () => gravityIsolation(0.85)
+  },
+  {
+    id: 'feature-window',
+    label: 'Feature window',
+    description: 'Averages the last eight samples to reduce jitter before mapping.',
+    factory: () => featureWindow(8)
+  }
+];
+
+const preprocessorHandles = new Map<string, PreprocessorRegistration>();
+const preprocessorCheckboxes = new Map<string, HTMLInputElement>();
+const preprocessorLookup = new Map(PREPROCESSOR_OPTIONS.map(option => [option.id, option]));
+
+rotationBus.subscribe(snapshot => {
+  const normalized = normalizeSnapshot(snapshot);
+  lastExtrumentSummary = describeSnapshot(normalized);
+  extrumentPayloadEl.textContent = lastExtrumentSummary;
+  void extrumentHub.broadcastPayload(normalized);
+});
+
+populateParseratorProfiles();
+renderParseratorPreprocessors();
+
+const hydratedIngestion = persistedManifest?.ingestion;
+if (hydratedIngestion) {
+  const profile = getProfileById(hydratedIngestion.profileId) ?? DEFAULT_PROFILE;
+  parserator.setProfile(profile);
+  parserator.setConfidenceFloor(hydratedIngestion.confidenceFloor);
+  for (const id of hydratedIngestion.preprocessors) {
+    const option = preprocessorLookup.get(id);
+    if (option) {
+      setPreprocessorState(option, true, false);
+    }
+  }
+} else {
+  parserator.setProfile(DEFAULT_PROFILE);
+}
+
+parseratorProfileSelect.addEventListener('change', event => {
+  const target = event.target as HTMLSelectElement;
+  const profile = getProfileById(target.value) ?? DEFAULT_PROFILE;
+  parserator.setProfile(profile);
+  updateParseratorTelemetry();
+  persistIngestionConfig();
+});
+
+parseratorConfidenceInput.addEventListener('input', () => {
+  setConfidenceFloor(Number(parseratorConfidenceInput.value), false);
+});
+
+parseratorConfidenceInput.addEventListener('change', () => {
+  setConfidenceFloor(Number(parseratorConfidenceInput.value), true);
+});
+
+updateParseratorTelemetry();
+
+if (!hydratedIngestion) {
+  persistIngestionConfig();
+}
 
 const rotationState: RotationSnapshot = {
   ...ZERO_ROTATION,
@@ -33,21 +232,278 @@ const manualOffsets: RotationAngles = { ...ZERO_ROTATION };
 const autoAngles: RotationAngles = { ...ZERO_ROTATION };
 
 let updateRotationLabels: (combined: RotationAngles, manual: RotationAngles) => void;
+let lastExtrumentSummary = '–';
 
 function pushRotationSnapshot(timestamp: number) {
   rotationState.timestamp = timestamp;
 
-  let energy = 0;
   for (const plane of SIX_PLANE_KEYS) {
     rotationState[plane] = autoAngles[plane] + manualOffsets[plane];
-    energy += Math.abs(rotationState[plane]);
   }
+
+  const energy = rotationEnergy(rotationState);
 
   const normalized = Math.min(1, energy / (Math.PI * SIX_PLANE_KEYS.length));
   rotationState.confidence = 0.75 + 0.25 * (1 - normalized);
 
   rotationBus.push({ ...rotationState });
   updateRotationLabels(rotationState, manualOffsets);
+  updateTelemetry();
+}
+
+function formatLatency(avg: number, max: number) {
+  if (avg <= 0 && max <= 0) {
+    return '0 ms';
+  }
+  return `${avg.toFixed(1)} ms (max ${max.toFixed(1)})`;
+}
+
+function updateManifestTelemetry() {
+  const manifest = manifestBuilder.getManifest();
+  manifestFramesEl.textContent = manifest.stats.totalFrames.toString();
+  manifestP95El.textContent =
+    manifest.stats.totalFrames && manifest.stats.p95TotalLatencyMs
+      ? `${manifest.stats.p95TotalLatencyMs.toFixed(1)} ms`
+      : '–';
+  manifestUpdatedEl.textContent = manifest.stats.totalFrames
+    ? formatManifestTimestamp(manifest.stats.lastUpdated)
+    : '–';
+  manifestDownloadButton.disabled = manifest.stats.totalFrames === 0;
+}
+
+function formatManifestTimestamp(timestamp: number): string {
+  if (!Number.isFinite(timestamp)) {
+    return '–';
+  }
+  const now = Date.now();
+  const delta = now - timestamp;
+
+  if (!Number.isFinite(delta) || delta < 0) {
+    return new Date(timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+  }
+
+  if (delta < 1_000) {
+    return `${Math.max(0, Math.round(delta))} ms ago`;
+  }
+
+  if (delta < 60_000) {
+    const seconds = delta / 1_000;
+    const precision = seconds < 10 ? 1 : 0;
+    return `${seconds.toFixed(precision)} s ago`;
+  }
+
+  if (delta < 3_600_000) {
+    const minutes = Math.floor(delta / 60_000);
+    const seconds = Math.floor((delta % 60_000) / 1_000);
+    if (minutes >= 10 || seconds === 0) {
+      return `${minutes} min ago`;
+    }
+    return `${minutes}m ${seconds}s ago`;
+  }
+
+  const date = new Date(timestamp);
+  return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+}
+
+function persistManifest() {
+  try {
+    if (typeof localStorage === 'undefined') {
+      return;
+    }
+    const manifest = manifestBuilder.getManifest();
+    localStorage.setItem(DATASET_MANIFEST_STORAGE_KEY, JSON.stringify(manifest));
+  } catch (error) {
+    console.warn('Failed to persist dataset manifest', error);
+  }
+}
+
+function populateParseratorProfiles() {
+  parseratorProfileSelect.innerHTML = '';
+  for (const profile of AVAILABLE_PROFILES) {
+    const option = document.createElement('option');
+    option.value = profile.id;
+    option.textContent = profile.name;
+    parseratorProfileSelect.appendChild(option);
+  }
+}
+
+function renderParseratorPreprocessors() {
+  parseratorPreprocessorContainer.innerHTML = '';
+  preprocessorCheckboxes.clear();
+
+  for (const option of PREPROCESSOR_OPTIONS) {
+    const label = document.createElement('label');
+    label.className = 'parserator-toggle';
+
+    const checkbox = document.createElement('input');
+    checkbox.type = 'checkbox';
+    checkbox.value = option.id;
+    checkbox.addEventListener('change', () => {
+      setPreprocessorState(option, checkbox.checked);
+    });
+
+    const textContainer = document.createElement('div');
+    const title = document.createElement('span');
+    title.textContent = option.label;
+    const hint = document.createElement('small');
+    hint.textContent = option.description;
+    textContainer.appendChild(title);
+    textContainer.appendChild(hint);
+
+    label.appendChild(checkbox);
+    label.appendChild(textContainer);
+    parseratorPreprocessorContainer.appendChild(label);
+    preprocessorCheckboxes.set(option.id, checkbox);
+  }
+}
+
+function setPreprocessorState(option: PreprocessorOption, enabled: boolean, persist = true) {
+  const current = preprocessorHandles.get(option.id);
+  if (enabled && !current) {
+    const registration = parserator.registerPreprocessor(option.factory(), { id: option.id });
+    preprocessorHandles.set(option.id, registration);
+  } else if (!enabled && current) {
+    current.dispose();
+    preprocessorHandles.delete(option.id);
+  }
+
+  updateParseratorTelemetry();
+
+  if (persist) {
+    persistIngestionConfig();
+  }
+}
+
+function setConfidenceFloor(value: number, persist = true) {
+  const clamped = Math.min(1, Math.max(0, Number.isFinite(value) ? value : parserator.getConfidenceFloor()));
+  parserator.setConfidenceFloor(clamped);
+  updateParseratorTelemetry();
+  if (persist) {
+    persistIngestionConfig();
+  }
+}
+
+function persistIngestionConfig() {
+  const profile = parserator.getProfile();
+  manifestBuilder.updateIngestionConfig({
+    profileId: profile.id,
+    profileName: profile.name,
+    confidenceFloor: parserator.getConfidenceFloor(),
+    preprocessors: parserator.listPreprocessors()
+  });
+  persistManifest();
+}
+
+function updateParseratorTelemetry() {
+  const profile = parserator.getProfile();
+  parseratorProfileNameEl.textContent = profile.name;
+  parseratorProfileSelect.value = profile.id;
+
+  const confidence = parserator.getConfidenceFloor();
+  parseratorConfidenceValueEl.textContent = confidence.toFixed(2);
+  parseratorConfidenceInput.value = confidence.toFixed(2);
+
+  const activeIds = parserator.listPreprocessors();
+  if (!activeIds.length) {
+    parseratorPreprocessorsEl.textContent = '–';
+  } else {
+    parseratorPreprocessorsEl.textContent = activeIds
+      .map(id => preprocessorLookup.get(id)?.label ?? id)
+      .join(', ');
+  }
+
+  for (const [id, checkbox] of preprocessorCheckboxes) {
+    checkbox.checked = preprocessorHandles.has(id);
+  }
+}
+
+function updateTelemetry() {
+  const uniformMetrics = core.getUniformMetrics();
+  uniformUploadsEl.textContent = `${uniformMetrics.uploads}/${uniformMetrics.enqueued}`;
+  uniformSkipsEl.textContent = uniformMetrics.skipped.toString();
+  latencyTracker.recordUniform(uniformMetrics);
+
+  const pipelineLatency = latencyTracker.getMetrics();
+  uniformLatencyEl.textContent = formatLatency(pipelineLatency.uniformAvgMs, pipelineLatency.uniformMaxMs);
+  captureLatencyEl.textContent = formatLatency(pipelineLatency.captureAvgMs, pipelineLatency.captureMaxMs);
+  encodeLatencyEl.textContent = formatLatency(pipelineLatency.encodeAvgMs, pipelineLatency.encodeMaxMs);
+
+  const datasetMetrics = datasetExport.getMetrics();
+  datasetPendingEl.textContent = datasetMetrics.pending.toString();
+  datasetTotalEl.textContent = datasetMetrics.totalEncoded.toString();
+  datasetFormatEl.textContent = datasetMetrics.lastFormat ?? '–';
+  updateManifestTelemetry();
+}
+
+async function connectExtruments() {
+  if (extrumentConnected) {
+    updateExtrumentStatus();
+    return;
+  }
+
+  extrumentConnectButton.disabled = true;
+  extrumentStatusEl.textContent = 'Scanning MIDI…';
+
+  try {
+    const navigatorWithMidi = navigator as Navigator & { requestMIDIAccess?: () => Promise<any> };
+    if (!navigatorWithMidi.requestMIDIAccess) {
+      extrumentStatusEl.textContent = 'WebMIDI unavailable';
+      extrumentConnectButton.disabled = false;
+      return;
+    }
+
+    const adapters = await discoverMidiAdapters({
+      accessFactory: () => navigatorWithMidi.requestMIDIAccess!()
+    });
+
+    if (!adapters.length) {
+      extrumentStatusEl.textContent = 'No MIDI outputs found';
+      extrumentConnectButton.disabled = false;
+      return;
+    }
+
+    extrumentDisconnectors.forEach(dispose => dispose());
+    extrumentDisconnectors.length = 0;
+
+    for (const adapter of adapters) {
+      extrumentAdapterLabels.set(adapter.id, adapter.label ?? adapter.id);
+      const dispose = extrumentHub.register(adapter);
+      extrumentDisconnectors.push(dispose);
+      await extrumentHub.connect(adapter.id);
+    }
+
+    extrumentConnected = true;
+    extrumentStatusEl.textContent = `Connected · ${adapters.length}`;
+    extrumentConnectButton.textContent = 'MIDI Connected';
+    extrumentConnectButton.disabled = true;
+    updateExtrumentStatus();
+    extrumentPayloadEl.textContent = lastExtrumentSummary;
+  } catch (error) {
+    console.error('Failed to connect extruments', error);
+    extrumentStatusEl.textContent = 'Connection failed';
+    extrumentConnectButton.disabled = false;
+  }
+}
+
+function updateExtrumentStatus() {
+  const states = extrumentHub.listAdapters();
+  if (!states.length) {
+    extrumentStatusEl.textContent = extrumentConnected ? 'Connected' : 'Idle';
+    if (!extrumentConnected) {
+      extrumentOutputEl.textContent = '–';
+    }
+    return;
+  }
+  const connected = states.filter(state => state.connected);
+  if (connected.length) {
+    extrumentStatusEl.textContent = `Connected · ${connected.length}`;
+  } else {
+    extrumentStatusEl.textContent = 'Ready';
+  }
+  const labels = states
+    .map(state => extrumentAdapterLabels.get(state.id) ?? state.id.replace(/^midi:/, ''))
+    .join(', ');
+  extrumentOutputEl.textContent = labels || '–';
 }
 
 updateRotationLabels = createRotationControls(rotationControlsContainer, manualOffsets, () => {
@@ -56,12 +512,36 @@ updateRotationLabels = createRotationControls(rotationControlsContainer, manualO
 
 pushRotationSnapshot(performance.now());
 
+extrumentConnectButton.addEventListener('click', () => {
+  void connectExtruments();
+});
+
+manifestDownloadButton.addEventListener('click', downloadManifest);
+
+updateExtrumentStatus();
+updateManifestTelemetry();
+
+window.addEventListener('beforeunload', () => {
+  extrumentDisconnectors.forEach(dispose => dispose());
+});
+
+function populateGeometryOptions() {
+  const geometries = geometryController.getAvailableGeometries();
+  geometrySelect.innerHTML = '';
+  for (const descriptor of geometries) {
+    const option = document.createElement('option');
+    option.value = descriptor.id;
+    option.textContent = descriptor.name;
+    geometrySelect.appendChild(option);
+  }
+}
+
 function setGeometry(id: GeometryId) {
-  const geometry = getGeometry(id);
-  core.setGeometry(geometry);
-  const vertexCount = (geometry.positions.length / 4).toFixed(0);
-  const edgeCount = (geometry.indices.length / 2).toFixed(0);
-  statusEl.textContent = `Geometry: ${id} · vertices ${vertexCount} · edges ${edgeCount}`;
+  geometryController.setActiveGeometry(id);
+  const descriptor = geometryController.getDescriptor(id);
+  if (!descriptor) return;
+  const { topology } = descriptor.data;
+  statusEl.textContent = `Geometry: ${descriptor.name} · V ${topology.vertices} · E ${topology.edges} · F ${topology.faces} · C ${topology.cells}`;
 }
 
 geometrySelect.addEventListener('change', (event) => {
@@ -79,9 +559,82 @@ lineWidthSlider.addEventListener('input', (event) => {
   core.setLineWidth(value);
 });
 
+populateGeometryOptions();
+geometrySelect.value = 'tesseract';
 setGeometry('tesseract');
+core.setUniformUploadListener((snapshot, metrics) => {
+  latencyTracker.recordUniform(metrics);
+  const datasetMetrics = datasetExport.getMetrics();
+  if (datasetMetrics.pending >= MAX_PENDING_FRAMES) {
+    return;
+  }
+
+  const frame = core.captureFrame();
+  if (frame.width === 0 || frame.height === 0) {
+    return;
+  }
+
+  const captureTime = performance.now();
+  const captureLatency = Math.max(0, captureTime - snapshot.timestamp);
+  latencyTracker.recordCapture(snapshot.timestamp, captureTime);
+
+  let uniformLatency = metrics.lastUploadLatency;
+  if (metrics.lastSnapshotTimestamp !== snapshot.timestamp) {
+    uniformLatency = Math.max(0, metrics.lastUploadTime - snapshot.timestamp);
+  }
+
+  datasetExport.enqueue({
+    width: frame.width,
+    height: frame.height,
+    pixels: frame.pixels,
+    metadata: {
+      timestamp: snapshot.timestamp,
+      rotationAngles: [snapshot.xy, snapshot.xz, snapshot.yz, snapshot.xw, snapshot.yw, snapshot.zw],
+      latency: {
+        uniformMs: uniformLatency,
+        uniformTimestamp: metrics.lastUploadTime,
+        captureMs: captureLatency,
+        captureTimestamp: captureTime
+      }
+    }
+  });
+  updateTelemetry();
+});
+
 startSyntheticRotation(autoAngles, timestamp => pushRotationSnapshot(timestamp));
 core.start();
+
+setInterval(() => focusDirector.update(performance.now()), 1000);
+
+setInterval(async () => {
+  const frames = await datasetExport.flush();
+  if (frames.length) {
+    const metrics = datasetExport.getMetrics();
+    const format = metrics.lastFormat ?? 'image/png';
+    frames.forEach(frame => {
+      manifestBuilder.addFrame(frame.metadata, format);
+      pspStream.publish(frame);
+    });
+    persistManifest();
+    updateTelemetry();
+  }
+}, 2000);
+
+function downloadManifest() {
+  const manifest = manifestBuilder.getManifest();
+  const contents = JSON.stringify(manifest, null, 2);
+  const blob = new Blob([contents], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = createManifestDownloadName(manifest);
+  anchor.style.display = 'none';
+  const host = document.body ?? document.documentElement;
+  host?.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+  setTimeout(() => URL.revokeObjectURL(url), 0);
+}
 
 function createRotationControls(
   container: HTMLDivElement,
@@ -149,8 +702,11 @@ function startSyntheticRotation(autoState: RotationAngles, onUpdate: (timestamp:
     }
 
     onUpdate(now);
-    requestAnimationFrame(tick);
-  };
+  requestAnimationFrame(tick);
+};
 
   requestAnimationFrame(tick);
 }
+
+updateTelemetry();
+setInterval(updateTelemetry, 1000);

--- a/src/pipeline/contextScheduler.test.ts
+++ b/src/pipeline/contextScheduler.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { ContextScheduler } from './contextScheduler';
+
+describe('ContextScheduler', () => {
+  it('caps contexts and memory budgets', () => {
+    const scheduler = new ContextScheduler();
+    for (let i = 0; i < 25; i++) {
+      scheduler.registerContext({
+        id: `ctx-${i}`,
+        priority: i < 5 ? 'critical' : 'background',
+        memoryMB: 128
+      });
+    }
+    const snapshot = scheduler.getSnapshot();
+    expect(snapshot.active.length).toBeLessThanOrEqual(20);
+    expect(snapshot.rejected.length).toBeGreaterThan(0);
+    expect(snapshot.totalMemory).toBeLessThanOrEqual(4096);
+  });
+});

--- a/src/pipeline/contextScheduler.ts
+++ b/src/pipeline/contextScheduler.ts
@@ -1,0 +1,48 @@
+export type ContextPriority = 'critical' | 'interactive' | 'background';
+
+export interface ContextDescriptor {
+  id: string;
+  priority: ContextPriority;
+  memoryMB: number;
+}
+
+export interface SchedulerSnapshot {
+  active: ContextDescriptor[];
+  totalMemory: number;
+  rejected: ContextDescriptor[];
+}
+
+const PRIORITY_ORDER: ContextPriority[] = ['critical', 'interactive', 'background'];
+const MAX_CONTEXTS = 20;
+const MAX_MEMORY_MB = 4096;
+
+export class ContextScheduler {
+  private readonly contexts: ContextDescriptor[] = [];
+  private readonly rejected: ContextDescriptor[] = [];
+
+  registerContext(descriptor: ContextDescriptor) {
+    this.contexts.push(descriptor);
+    this.contexts.sort((a, b) => PRIORITY_ORDER.indexOf(a.priority) - PRIORITY_ORDER.indexOf(b.priority));
+    this.enforceBudgets();
+  }
+
+  getSnapshot(): SchedulerSnapshot {
+    return {
+      active: this.contexts.slice(),
+      totalMemory: this.contexts.reduce((sum, context) => sum + context.memoryMB, 0),
+      rejected: this.rejected.slice()
+    };
+  }
+
+  private enforceBudgets() {
+    while (this.contexts.length > MAX_CONTEXTS || this.totalMemory() > MAX_MEMORY_MB) {
+      const removed = this.contexts.pop();
+      if (!removed) break;
+      this.rejected.push(removed);
+    }
+  }
+
+  private totalMemory(): number {
+    return this.contexts.reduce((sum, context) => sum + context.memoryMB, 0);
+  }
+}

--- a/src/pipeline/datasetExport.test.ts
+++ b/src/pipeline/datasetExport.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from 'vitest';
+import { DatasetExportService } from './datasetExport';
+import { encodeFrameToBlob } from './frameEncoding';
+
+interface WorkerRequest {
+  id: number;
+  format: 'image/png';
+  frame: {
+    width: number;
+    height: number;
+    pixels: Uint8ClampedArray;
+    metadata: { timestamp: number; rotationAngles: [number, number, number, number, number, number] };
+  };
+}
+
+interface WorkerResponse {
+  id: number;
+  success: boolean;
+  blob?: Blob;
+  error?: string;
+}
+
+class FakeWorker extends EventTarget implements Worker {
+  onmessage: ((this: Worker, ev: MessageEvent<WorkerResponse>) => unknown) | null = null;
+  onerror: ((this: Worker, ev: ErrorEvent) => unknown) | null = null;
+  onmessageerror: ((this: Worker, ev: MessageEvent) => unknown) | null = null;
+
+  constructor(private readonly handler: (data: WorkerRequest) => Promise<WorkerResponse>) {
+    super();
+  }
+
+  postMessage(message: WorkerRequest, _transfer?: Transferable[]): void {
+    void this.handler(message)
+      .then(response => {
+        this.onmessage?.call(this, { data: response } as MessageEvent<WorkerResponse>);
+      })
+      .catch(error => {
+        this.onerror?.call(this, new ErrorEvent('error', { message: (error as Error).message }));
+      });
+  }
+
+  terminate(): void {}
+}
+
+describe('DatasetExportService', () => {
+  it('encodes frames via JSON fallback when OffscreenCanvas is unavailable', async () => {
+    const service = new DatasetExportService();
+    expect(service.getMetrics()).toMatchObject({ pending: 0, totalEncoded: 0, lastFormat: null });
+    service.enqueue({
+      width: 2,
+      height: 2,
+      pixels: new Uint8ClampedArray([255, 0, 0, 255, 0, 255, 0, 255, 0, 0, 255, 255, 255, 255, 255, 255]),
+      metadata: {
+        timestamp: 1,
+        rotationAngles: [0, 0, 0, 0, 0, 0],
+        latency: {
+          uniformMs: 2,
+          uniformTimestamp: 3,
+          captureMs: 4,
+          captureTimestamp: 5
+        }
+      }
+    });
+    expect(service.getMetrics().pending).toBe(1);
+    const [frame] = await service.flush();
+    expect(frame.metadata.timestamp).toBe(1);
+    const text = await frame.blob.text();
+    expect(text).toContain('checksum');
+    const latency = frame.metadata.latency;
+    expect(latency).toBeDefined();
+    expect(latency?.uniformMs).toBe(2);
+    expect(latency?.captureMs).toBe(4);
+    expect(latency?.captureTimestamp).toBe(5);
+    expect(latency?.encodeMs).toBeGreaterThanOrEqual(0);
+    expect(latency?.encodeCompletedTimestamp).toBeGreaterThanOrEqual(latency!.captureTimestamp);
+    expect(latency?.totalMs).toBeCloseTo((latency?.encodeCompletedTimestamp ?? 0) - frame.metadata.timestamp, 5);
+    const metrics = service.getMetrics();
+    expect(metrics.pending).toBe(0);
+    expect(metrics.totalEncoded).toBe(1);
+    expect(metrics.lastFormat).toBe('image/png');
+    expect(metrics.lastLatencyMs).toBeGreaterThanOrEqual(0);
+    expect(metrics.averageLatencyMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it('dispatches frames through a worker when provided', async () => {
+    const workerFactory = () =>
+      new FakeWorker(async (message: WorkerRequest) => {
+        const blob = await encodeFrameToBlob(message.frame, message.format);
+        return { id: message.id, success: true, blob } satisfies WorkerResponse;
+      }) as unknown as Worker;
+
+    let samples: number[] = [];
+    const service = new DatasetExportService({
+      workerFactory,
+      onLatencySample: latency => samples.push(latency)
+    });
+
+    service.enqueue({
+      width: 2,
+      height: 2,
+      pixels: new Uint8ClampedArray([0, 0, 0, 255, 255, 255, 255, 255, 64, 64, 64, 255, 128, 128, 128, 255]),
+      metadata: {
+        timestamp: 2,
+        rotationAngles: [0, 0, 0, 0, 0, 0],
+        latency: {
+          uniformMs: 1.5,
+          captureMs: 3,
+          captureTimestamp: 10
+        }
+      }
+    });
+
+    const frames = await service.flush('image/png');
+    expect(frames).toHaveLength(1);
+    const latency = frames[0].metadata.latency;
+    expect(latency?.encodeMs).toBeGreaterThanOrEqual(0);
+    expect(latency?.totalMs).toBeGreaterThan(0);
+    expect(samples.length).toBeGreaterThan(0);
+    expect(service.getMetrics().totalEncoded).toBe(1);
+    expect(service.getMetrics().lastLatencyMs).toBeGreaterThan(0);
+  });
+
+  it('annotates latency when metadata does not provide an envelope', async () => {
+    const service = new DatasetExportService();
+    service.enqueue({
+      width: 1,
+      height: 1,
+      pixels: new Uint8ClampedArray([0, 0, 0, 255]),
+      metadata: { timestamp: 4, rotationAngles: [0, 0, 0, 0, 0, 0] }
+    });
+
+    const [frame] = await service.flush();
+    expect(frame.metadata.latency).toBeDefined();
+    expect(frame.metadata.latency?.captureTimestamp).toBeGreaterThan(0);
+    expect(frame.metadata.latency?.totalMs).toBeGreaterThanOrEqual(0);
+  });
+});

--- a/src/pipeline/datasetExport.ts
+++ b/src/pipeline/datasetExport.ts
@@ -1,0 +1,206 @@
+import type {
+  FrameFormat,
+  FramePayload,
+  EncodedFrame,
+  FrameMetadata,
+  PipelineLatencyEnvelope
+} from './datasetTypes';
+import { encodeFrameToBlob } from './frameEncoding';
+
+export interface DatasetExportMetrics {
+  pending: number;
+  totalEncoded: number;
+  lastFormat: FrameFormat | null;
+  lastLatencyMs: number;
+  averageLatencyMs: number;
+}
+
+export interface DatasetExportOptions {
+  workerFactory?: () => Worker;
+  sampleWindow?: number;
+  onLatencySample?: (latencyMs: number) => void;
+}
+
+interface WorkerRequest {
+  id: number;
+  format: FrameFormat;
+  frame: FramePayload;
+}
+
+interface WorkerSuccess {
+  id: number;
+  success: true;
+  blob: Blob;
+}
+
+interface WorkerFailure {
+  id: number;
+  success: false;
+  error: string;
+}
+
+type WorkerResponse = WorkerSuccess | WorkerFailure;
+
+interface PendingJob {
+  resolve: (frame: EncodedFrame) => void;
+  reject: (error: Error) => void;
+  metadata: FrameMetadata;
+  start: number;
+}
+
+export class DatasetExportService {
+  private readonly queue: FramePayload[] = [];
+  private readonly latencies: number[] = [];
+  private readonly maxSamples: number;
+  private latencySum = 0;
+  private totalEncoded = 0;
+  private lastFormat: FrameFormat | null = null;
+  private lastLatency = 0;
+  private worker: Worker | null = null;
+  private jobId = 0;
+  private readonly pendingJobs = new Map<number, PendingJob>();
+
+  constructor(private readonly options: DatasetExportOptions = {}) {
+    this.maxSamples = options.sampleWindow ?? 32;
+    const worker = this.createWorker();
+    if (worker) {
+      this.worker = worker;
+      worker.onmessage = event => this.handleWorkerMessage(event.data as WorkerResponse);
+      worker.onerror = event => {
+        console.error('Dataset worker error', event);
+      };
+    }
+  }
+
+  enqueue(frame: FramePayload) {
+    this.queue.push(frame);
+  }
+
+  async flush(format: FrameFormat = 'image/png'): Promise<EncodedFrame[]> {
+    const frames = this.queue.splice(0);
+    if (frames.length === 0) {
+      return [];
+    }
+
+    const results = this.worker
+      ? await this.encodeWithWorker(frames, format)
+      : await this.encodeSequential(frames, format);
+
+    if (results.length > 0) {
+      this.totalEncoded += results.length;
+      this.lastFormat = format;
+    }
+    return results;
+  }
+
+  getMetrics(): DatasetExportMetrics {
+    return {
+      pending: this.queue.length,
+      totalEncoded: this.totalEncoded,
+      lastFormat: this.lastFormat,
+      lastLatencyMs: this.lastLatency,
+      averageLatencyMs: this.latencies.length ? this.latencySum / this.latencies.length : 0
+    };
+  }
+
+  private async encodeSequential(frames: FramePayload[], format: FrameFormat): Promise<EncodedFrame[]> {
+    const results: EncodedFrame[] = [];
+    for (const frame of frames) {
+      const start = performance.now();
+      const blob = await encodeFrameToBlob(frame, format);
+      const latency = performance.now() - start;
+      this.recordLatency(latency);
+      results.push({ blob, metadata: this.withEncodeLatency(frame.metadata, start, latency) });
+    }
+    return results;
+  }
+
+  private encodeWithWorker(frames: FramePayload[], format: FrameFormat): Promise<EncodedFrame[]> {
+    return Promise.all(frames.map(frame => this.enqueueJob(frame, format)));
+  }
+
+  private enqueueJob(frame: FramePayload, format: FrameFormat): Promise<EncodedFrame> {
+    if (!this.worker) {
+      throw new Error('Worker unavailable');
+    }
+    const id = ++this.jobId;
+    const start = performance.now();
+    return new Promise<EncodedFrame>((resolve, reject) => {
+      this.pendingJobs.set(id, { resolve, reject, metadata: frame.metadata, start });
+      try {
+        this.worker!.postMessage({ id, format, frame } satisfies WorkerRequest, [frame.pixels.buffer]);
+      } catch (error) {
+        this.pendingJobs.delete(id);
+        reject(error as Error);
+      }
+    });
+  }
+
+  private handleWorkerMessage(message: WorkerResponse) {
+    const job = this.pendingJobs.get(message.id);
+    if (!job) {
+      return;
+    }
+    this.pendingJobs.delete(message.id);
+    if (!message.success) {
+      job.reject(new Error(message.error));
+      return;
+    }
+    const latency = performance.now() - job.start;
+    this.recordLatency(latency);
+    job.resolve({ blob: message.blob, metadata: this.withEncodeLatency(job.metadata, job.start, latency) });
+  }
+
+  private recordLatency(latency: number) {
+    if (!Number.isFinite(latency) || latency < 0) {
+      return;
+    }
+    this.lastLatency = latency;
+    this.latencies.push(latency);
+    this.latencySum += latency;
+    if (this.latencies.length > this.maxSamples) {
+      const removed = this.latencies.shift();
+      if (removed !== undefined) {
+        this.latencySum -= removed;
+      }
+    }
+    if (this.options.onLatencySample) {
+      this.options.onLatencySample(latency);
+    }
+  }
+
+  private withEncodeLatency(metadata: FrameMetadata, start: number, encodeLatency: number): FrameMetadata {
+    const encodeCompletedTimestamp = start + encodeLatency;
+    const latency: PipelineLatencyEnvelope = {
+      uniformMs: metadata.latency?.uniformMs ?? 0,
+      uniformTimestamp: metadata.latency?.uniformTimestamp,
+      captureMs: metadata.latency?.captureMs ?? 0,
+      captureTimestamp: metadata.latency?.captureTimestamp ?? start,
+      encodeMs: encodeLatency,
+      encodeCompletedTimestamp,
+      totalMs: encodeCompletedTimestamp - metadata.timestamp
+    };
+
+    return {
+      ...metadata,
+      latency
+    };
+  }
+
+  private createWorker(): Worker | null {
+    if (this.options.workerFactory) {
+      return this.options.workerFactory();
+    }
+    if (typeof Worker === 'undefined') {
+      return null;
+    }
+    try {
+      return new Worker(new URL('./datasetWorker.ts', import.meta.url), { type: 'module' });
+    } catch (error) {
+      console.warn('Failed to initialise dataset export worker', error);
+      return null;
+    }
+  }
+}
+
+export type { EncodedFrame, FrameMetadata, PipelineLatencyEnvelope } from './datasetTypes';

--- a/src/pipeline/datasetManifest.test.ts
+++ b/src/pipeline/datasetManifest.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it, vi } from 'vitest';
+import { DatasetManifestBuilder, createManifestDownloadName } from './datasetManifest';
+
+const sampleAngles: [number, number, number, number, number, number] = [0, 0.1, 0.2, 0.3, 0.4, 0.5];
+
+describe('DatasetManifestBuilder', () => {
+  it('generates deterministic asset names and retains latency envelopes', () => {
+    const builder = new DatasetManifestBuilder({ sessionId: 'test-session', prefix: 'sample' });
+    builder.addFrame(
+      {
+        timestamp: 123,
+        rotationAngles: sampleAngles,
+        latency: {
+          uniformMs: 2,
+          captureMs: 3,
+          captureTimestamp: 10,
+          encodeMs: 5,
+          totalMs: 10
+        }
+      },
+      'image/png'
+    );
+
+    const manifest = builder.getManifest();
+    expect(manifest.id).toBe('test-session');
+    expect(manifest.frames).toHaveLength(1);
+    expect(manifest.frames[0].assetName).toBe('sample-000001.png');
+    expect(manifest.frames[0].latency?.totalMs).toBe(10);
+    expect(manifest.stats.totalFrames).toBe(1);
+    expect(manifest.stats.p95TotalLatencyMs).toBe(10);
+  });
+
+  it('rehydrates from an existing manifest and continues numbering', () => {
+    const initial = new DatasetManifestBuilder({ prefix: 'frame' });
+    initial.addFrame(
+      {
+        timestamp: 1,
+        rotationAngles: sampleAngles,
+        latency: { uniformMs: 1, captureMs: 2, captureTimestamp: 5, totalMs: 5 }
+      },
+      'image/png'
+    );
+
+    const resumed = new DatasetManifestBuilder({ hydrateFrom: initial.getManifest() });
+    const added = resumed.addFrame(
+      {
+        timestamp: 2,
+        rotationAngles: sampleAngles,
+        latency: { uniformMs: 2, captureMs: 4, captureTimestamp: 8, encodeMs: 4 }
+      },
+      'image/webp'
+    );
+
+    expect(added.assetName).toBe('frame-000002.webp');
+    const manifest = resumed.getManifest();
+    expect(manifest.frames).toHaveLength(2);
+    expect(manifest.stats.totalFrames).toBe(2);
+    expect(manifest.stats.p95TotalLatencyMs).toBeGreaterThanOrEqual(manifest.stats.averageTotalLatencyMs);
+    expect(manifest.stats.maxTotalLatencyMs).toBeGreaterThan(0);
+  });
+
+  it('calculates aggregate statistics even when total latency is omitted', () => {
+    const builder = new DatasetManifestBuilder({ prefix: 'capture' });
+    builder.addFrame(
+      {
+        timestamp: 3,
+        rotationAngles: sampleAngles,
+        latency: {
+          uniformMs: 3,
+          captureMs: 7,
+          captureTimestamp: 11
+        }
+      },
+      'image/png'
+    );
+
+    builder.addFrame(
+      {
+        timestamp: 4,
+        rotationAngles: sampleAngles,
+        latency: {
+          uniformMs: 4,
+          captureMs: 6,
+          captureTimestamp: 12,
+          encodeMs: 5
+        }
+      },
+      'image/png'
+    );
+
+    const manifest = builder.getManifest();
+    expect(manifest.stats.totalFrames).toBe(2);
+    expect(manifest.stats.averageTotalLatencyMs).toBeGreaterThan(0);
+    expect(manifest.stats.p95TotalLatencyMs).toBeGreaterThan(0);
+  });
+
+  it('creates sanitized manifest download names with timestamps', () => {
+    vi.useFakeTimers();
+    const now = new Date('2024-04-05T12:34:56.789Z');
+    vi.setSystemTime(now);
+
+    const builder = new DatasetManifestBuilder({ sessionId: 'Session 42', prefix: 'frame' });
+    const manifest = builder.getManifest();
+
+    const filename = createManifestDownloadName(manifest);
+    expect(filename).toBe('session-42-2024-04-05T12-34-56-789Z.manifest.json');
+
+    vi.useRealTimers();
+  });
+
+  it('records and rehydrates parserator ingestion metadata', () => {
+    const builder = new DatasetManifestBuilder({ sessionId: 'ingestion-session' });
+    builder.updateIngestionConfig({
+      profileId: 'default-imu',
+      profileName: 'Default IMU',
+      confidenceFloor: 0.65,
+      preprocessors: ['low-pass', 'gravity']
+    });
+
+    const manifest = builder.getManifest();
+    expect(manifest.ingestion?.profileId).toBe('default-imu');
+    expect(manifest.ingestion?.preprocessors).toEqual(['low-pass', 'gravity']);
+    expect(manifest.ingestion?.updatedAt).toBeGreaterThan(0);
+
+    const rehydrated = new DatasetManifestBuilder({ hydrateFrom: manifest });
+    expect(rehydrated.getManifest().ingestion?.profileId).toBe('default-imu');
+  });
+});

--- a/src/pipeline/datasetManifest.ts
+++ b/src/pipeline/datasetManifest.ts
@@ -1,0 +1,217 @@
+import type { FrameFormat, FrameMetadata, PipelineLatencyEnvelope } from './datasetTypes';
+
+export interface DatasetManifestFrame {
+  assetName: string;
+  format: FrameFormat;
+  timestamp: number;
+  rotationAngles: [number, number, number, number, number, number];
+  latency?: PipelineLatencyEnvelope;
+}
+
+export interface DatasetManifestStatistics {
+  totalFrames: number;
+  averageTotalLatencyMs: number;
+  p95TotalLatencyMs: number;
+  minTotalLatencyMs: number;
+  maxTotalLatencyMs: number;
+  lastUpdated: number;
+}
+
+export interface DatasetIngestionConfig {
+  profileId: string;
+  profileName?: string;
+  confidenceFloor: number;
+  preprocessors: string[];
+  updatedAt: number;
+}
+
+export interface DatasetManifest {
+  id: string;
+  createdAt: number;
+  prefix: string;
+  frames: DatasetManifestFrame[];
+  stats: DatasetManifestStatistics;
+  ingestion?: DatasetIngestionConfig;
+}
+
+export interface DatasetManifestBuilderOptions {
+  sessionId?: string;
+  prefix?: string;
+  startIndex?: number;
+  hydrateFrom?: DatasetManifest;
+}
+
+export const DATASET_MANIFEST_STORAGE_KEY = 'hypercube-core-dataset-manifest';
+
+const DEFAULT_PREFIX = 'frame';
+const DEFAULT_SESSION_PREFIX = 'dataset';
+
+export function createManifestDownloadName(manifest: DatasetManifest): string {
+  const baseId = manifest.id.trim() || DEFAULT_SESSION_PREFIX;
+  const normalizedId =
+    baseId
+      .toLowerCase()
+      .replace(/[^a-z0-9-_]+/g, '-')
+      .replace(/-+/g, '-')
+      .replace(/^-|-$/g, '') || DEFAULT_SESSION_PREFIX;
+  const timestampSource = manifest.stats.lastUpdated || manifest.createdAt || Date.now();
+  const timestamp = new Date(timestampSource).toISOString().replace(/[:.]/g, '-');
+  return `${normalizedId}-${timestamp}.manifest.json`;
+}
+
+export class DatasetManifestBuilder {
+  private readonly prefix: string;
+  private manifest: DatasetManifest;
+  private nextIndex: number;
+  private readonly totalLatencies: number[] = [];
+
+  constructor(options: DatasetManifestBuilderOptions = {}) {
+    this.prefix = options.prefix ?? options.hydrateFrom?.prefix ?? DEFAULT_PREFIX;
+
+    if (options.hydrateFrom) {
+      this.manifest = cloneManifest(options.hydrateFrom);
+      this.nextIndex = this.manifest.frames.length + (options.startIndex ?? 0);
+      for (const frame of this.manifest.frames) {
+        const latency = computeTotalLatency(frame.latency);
+        if (latency !== null) {
+          this.totalLatencies.push(latency);
+        }
+      }
+      this.updateStatistics();
+    } else {
+      const sessionId = options.sessionId ?? createSessionId();
+      this.manifest = {
+        id: sessionId,
+        createdAt: Date.now(),
+        prefix: this.prefix,
+        frames: [],
+        stats: createEmptyStats()
+      };
+      this.nextIndex = options.startIndex ?? 0;
+    }
+  }
+
+  addFrame(metadata: FrameMetadata, format: FrameFormat): DatasetManifestFrame {
+    const assetName = this.createAssetName(format);
+    const frame: DatasetManifestFrame = {
+      assetName,
+      format,
+      timestamp: metadata.timestamp,
+      rotationAngles: metadata.rotationAngles,
+      latency: metadata.latency
+    };
+
+    this.manifest.frames.push(frame);
+    this.nextIndex += 1;
+
+    const latency = computeTotalLatency(metadata.latency);
+    if (latency !== null) {
+      this.totalLatencies.push(latency);
+    }
+
+    this.updateStatistics();
+
+    return frame;
+  }
+
+  getManifest(): DatasetManifest {
+    return cloneManifest(this.manifest);
+  }
+
+  updateIngestionConfig(config: Omit<DatasetIngestionConfig, 'updatedAt'>): void {
+    this.manifest.ingestion = {
+      ...config,
+      updatedAt: Date.now()
+    };
+  }
+
+  private createAssetName(format: FrameFormat): string {
+    const extension = formatToExtension(format);
+    const index = this.nextIndex + 1;
+    return `${this.prefix}-${index.toString().padStart(6, '0')}.${extension}`;
+  }
+
+  private updateStatistics() {
+    const count = this.manifest.frames.length;
+    if (count === 0) {
+      this.manifest.stats = createEmptyStats();
+      return;
+    }
+
+    const latencies = [...this.totalLatencies].sort((a, b) => a - b);
+    const sum = this.totalLatencies.reduce((total, value) => total + value, 0);
+    const average = this.totalLatencies.length ? sum / this.totalLatencies.length : 0;
+    const min = this.totalLatencies.length ? latencies[0] : 0;
+    const max = this.totalLatencies.length ? latencies[latencies.length - 1] : 0;
+    const p95 = this.totalLatencies.length ? percentile(latencies, 0.95) : 0;
+
+    this.manifest.stats = {
+      totalFrames: count,
+      averageTotalLatencyMs: average,
+      minTotalLatencyMs: min,
+      maxTotalLatencyMs: max,
+      p95TotalLatencyMs: p95,
+      lastUpdated: Date.now()
+    };
+  }
+}
+
+function createSessionId() {
+  return `${DEFAULT_SESSION_PREFIX}-${Date.now().toString(36)}`;
+}
+
+function createEmptyStats(): DatasetManifestStatistics {
+  return {
+    totalFrames: 0,
+    averageTotalLatencyMs: 0,
+    p95TotalLatencyMs: 0,
+    minTotalLatencyMs: 0,
+    maxTotalLatencyMs: 0,
+    lastUpdated: Date.now()
+  };
+}
+
+function formatToExtension(format: FrameFormat): string {
+  switch (format) {
+    case 'image/png':
+      return 'png';
+    case 'image/webp':
+      return 'webp';
+    case 'video/webm':
+      return 'webm';
+    default:
+      return 'bin';
+  }
+}
+
+function computeTotalLatency(envelope: PipelineLatencyEnvelope | undefined): number | null {
+  if (!envelope) {
+    return null;
+  }
+  if (typeof envelope.totalMs === 'number') {
+    return envelope.totalMs;
+  }
+  const parts = [envelope.uniformMs, envelope.captureMs, envelope.encodeMs ?? 0].filter(
+    value => typeof value === 'number' && Number.isFinite(value)
+  ) as number[];
+  if (!parts.length) {
+    return null;
+  }
+  const total = parts.reduce((sum, value) => sum + value, 0);
+  return Number.isFinite(total) ? total : null;
+}
+
+function percentile(sortedValues: number[], percentileRank: number): number {
+  if (!sortedValues.length) {
+    return 0;
+  }
+  const index = Math.min(sortedValues.length - 1, Math.ceil(sortedValues.length * percentileRank) - 1);
+  return sortedValues[index];
+}
+
+function cloneManifest(manifest: DatasetManifest): DatasetManifest {
+  if (typeof globalThis.structuredClone === 'function') {
+    return globalThis.structuredClone(manifest);
+  }
+  return JSON.parse(JSON.stringify(manifest)) as DatasetManifest;
+}

--- a/src/pipeline/datasetTypes.ts
+++ b/src/pipeline/datasetTypes.ts
@@ -1,0 +1,36 @@
+export type FrameFormat = 'image/png' | 'image/webp' | 'video/webm';
+
+export interface PipelineLatencyEnvelope {
+  /** Time from the originating sensor sample to the uniform upload that consumed it. */
+  uniformMs: number;
+  /** Wall-clock timestamp (performance.now) when the uniform upload completed. */
+  uniformTimestamp?: number;
+  /** Time from the originating sensor sample to when the frame pixels were captured. */
+  captureMs: number;
+  /** Wall-clock timestamp when the capture completed. */
+  captureTimestamp: number;
+  /** Time spent encoding the captured frame. */
+  encodeMs?: number;
+  /** Wall-clock timestamp when encoding finished. */
+  encodeCompletedTimestamp?: number;
+  /** Aggregate end-to-end latency from sensor sample to encoded payload availability. */
+  totalMs?: number;
+}
+
+export interface FrameMetadata {
+  timestamp: number;
+  rotationAngles: [number, number, number, number, number, number];
+  latency?: PipelineLatencyEnvelope;
+}
+
+export interface FramePayload {
+  width: number;
+  height: number;
+  pixels: Uint8ClampedArray;
+  metadata: FrameMetadata;
+}
+
+export interface EncodedFrame {
+  blob: Blob;
+  metadata: FrameMetadata;
+}

--- a/src/pipeline/datasetWorker.ts
+++ b/src/pipeline/datasetWorker.ts
@@ -1,0 +1,39 @@
+/// <reference lib="webworker" />
+import { encodeFrameToBlob } from './frameEncoding';
+import type { FrameFormat, FramePayload } from './datasetTypes';
+
+interface WorkerRequest {
+  id: number;
+  format: FrameFormat;
+  frame: FramePayload;
+}
+
+interface WorkerSuccess {
+  id: number;
+  success: true;
+  blob: Blob;
+}
+
+interface WorkerFailure {
+  id: number;
+  success: false;
+  error: string;
+}
+
+type WorkerResponse = WorkerSuccess | WorkerFailure;
+
+const ctx: DedicatedWorkerGlobalScope = self as unknown as DedicatedWorkerGlobalScope;
+
+ctx.onmessage = async event => {
+  const message = event.data as WorkerRequest;
+  try {
+    const blob = await encodeFrameToBlob(message.frame, message.format);
+    post({ id: message.id, success: true, blob });
+  } catch (error) {
+    post({ id: message.id, success: false, error: (error as Error).message });
+  }
+};
+
+function post(response: WorkerResponse) {
+  ctx.postMessage(response);
+}

--- a/src/pipeline/focusDirector.test.ts
+++ b/src/pipeline/focusDirector.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { FocusDirector } from './focusDirector';
+import { RotationBus } from './rotationBus';
+import type { GeometryDescriptor } from '../geometry/types';
+import type { GeometryId } from './geometryCatalog';
+
+class FakeGeometryController {
+  active: GeometryId | null = null;
+  constructor(private readonly geometries: GeometryDescriptor[]) {}
+  getAvailableGeometries() {
+    return this.geometries;
+  }
+  setActiveGeometry(id: GeometryId) {
+    this.active = id;
+  }
+}
+
+describe('FocusDirector', () => {
+  it('applies focus hints and falls back on timeout', () => {
+    const geometries = [{
+      id: 'tesseract',
+      name: 'Tesseract',
+      data: {
+        positions: new Float32Array(0),
+        indices: new Uint16Array(0),
+        drawMode: 0,
+        vertexStride: 4,
+        topology: { vertices: 16, edges: 32, faces: 24, cells: 8 }
+      }
+    } as GeometryDescriptor];
+    const controller = new FakeGeometryController(geometries);
+    const bus = new RotationBus();
+    const director = new FocusDirector(controller as any, bus, { timeoutMs: 10 });
+
+    director.ingestHint({ geometry: 'tesseract', rotationBias: { xy: 0.5 } });
+    bus.push({
+      xy: 0,
+      xz: 0,
+      yz: 0,
+      xw: 0,
+      yw: 0,
+      zw: 0,
+      timestamp: performance.now(),
+      confidence: 0.5
+    });
+    director.update(performance.now());
+    expect(controller.active).toBe('tesseract');
+
+    director.update(performance.now() + 20);
+    expect(controller.active).toBe('tesseract');
+  });
+});

--- a/src/pipeline/focusDirector.ts
+++ b/src/pipeline/focusDirector.ts
@@ -1,0 +1,86 @@
+import type { GeometryId } from './geometryCatalog';
+import type { GeometryController } from './geometryController';
+import type { RotationBus } from './rotationBus';
+import type { RotationAngles, RotationSnapshot } from '../core/rotationUniforms';
+
+export interface FocusHint {
+  geometry?: GeometryId;
+  rotationBias?: Partial<RotationAngles>;
+  confidenceBoost?: number;
+}
+
+export interface FocusDirectorOptions {
+  fallbackGeometry?: GeometryId;
+  timeoutMs?: number;
+}
+
+export class FocusDirector {
+  private lastHintAt = 0;
+  private readonly timeoutMs: number;
+  private readonly fallbackGeometry: GeometryId;
+  private rotationBias: Partial<RotationAngles> = {};
+  private confidenceBoost = 0;
+
+  constructor(
+    private readonly geometryController: GeometryController,
+    private readonly rotationBus: RotationBus,
+    options: FocusDirectorOptions = {}
+  ) {
+    this.timeoutMs = options.timeoutMs ?? 5000;
+    this.fallbackGeometry = options.fallbackGeometry ?? 'tesseract';
+  }
+
+  ingestHint(hint: FocusHint) {
+    this.lastHintAt = performance.now();
+    if (hint.geometry) {
+      this.geometryController.setActiveGeometry(hint.geometry);
+    }
+    if (hint.rotationBias) {
+      this.rotationBias = { ...hint.rotationBias };
+    }
+    if (typeof hint.confidenceBoost === 'number') {
+      this.confidenceBoost = hint.confidenceBoost;
+    }
+  }
+
+  update(snapshotTime = performance.now()) {
+    if (snapshotTime - this.lastHintAt > this.timeoutMs) {
+      this.geometryController.setActiveGeometry(this.fallbackGeometry);
+      this.rotationBias = {};
+      this.confidenceBoost = 0;
+      this.lastHintAt = snapshotTime;
+    }
+
+    const latest = this.rotationBus.getLatest({
+      xy: 0,
+      xz: 0,
+      yz: 0,
+      xw: 0,
+      yw: 0,
+      zw: 0,
+      timestamp: snapshotTime,
+      confidence: 1
+    });
+
+    let mutated = false;
+    const nextSnapshot: RotationSnapshot = { ...latest };
+    if (this.rotationBias) {
+      (Object.keys(this.rotationBias) as (keyof RotationAngles)[]).forEach(plane => {
+        const value = this.rotationBias[plane];
+        if (typeof value === 'number') {
+          nextSnapshot[plane] += value;
+          mutated = true;
+        }
+      });
+    }
+    if (this.confidenceBoost !== 0) {
+      nextSnapshot.confidence = Math.min(1, latest.confidence + this.confidenceBoost);
+      mutated = true;
+    }
+
+    if (mutated) {
+      nextSnapshot.timestamp = snapshotTime;
+      this.rotationBus.push({ ...nextSnapshot });
+    }
+  }
+}

--- a/src/pipeline/frameEncoding.ts
+++ b/src/pipeline/frameEncoding.ts
@@ -1,0 +1,31 @@
+import type { FrameFormat, FramePayload } from './datasetTypes';
+
+export async function encodeFrameToBlob(frame: FramePayload, format: FrameFormat): Promise<Blob> {
+  if (typeof OffscreenCanvas !== 'undefined') {
+    const canvas = new OffscreenCanvas(frame.width, frame.height);
+    const context = canvas.getContext('2d');
+    if (!context) {
+      throw new Error('Unable to allocate offscreen context');
+    }
+    const imageData = new ImageData(frame.pixels, frame.width, frame.height);
+    context.putImageData(imageData, 0, 0);
+    return canvas.convertToBlob({ type: format });
+  }
+
+  const payload = {
+    format,
+    width: frame.width,
+    height: frame.height,
+    metadata: frame.metadata,
+    checksum: checksum(frame.pixels)
+  };
+  return new Blob([JSON.stringify(payload)], { type: 'application/json' });
+}
+
+export function checksum(pixels: Uint8ClampedArray): number {
+  let sum = 0;
+  for (let i = 0; i < pixels.length; i++) {
+    sum = (sum + pixels[i]) % 65536;
+  }
+  return sum;
+}

--- a/src/pipeline/geometryCatalog.ts
+++ b/src/pipeline/geometryCatalog.ts
@@ -1,8 +1,9 @@
+import { SixHundredCellGeometry } from '../geometry/sixHundredCell';
 import { TesseractGeometry } from '../geometry/tesseract';
 import { TwentyFourCellGeometry } from '../geometry/twentyFourCell';
 import type { GeometryData, GeometryDescriptor } from '../geometry/types';
 
-export type GeometryId = 'tesseract' | 'twentyFourCell';
+export type GeometryId = 'tesseract' | 'twentyFourCell' | 'sixHundredCell';
 
 const CATALOG: Record<GeometryId, GeometryDescriptor> = {
   tesseract: {
@@ -14,6 +15,11 @@ const CATALOG: Record<GeometryId, GeometryDescriptor> = {
     id: 'twentyFourCell',
     name: '24-Cell',
     data: TwentyFourCellGeometry
+  },
+  sixHundredCell: {
+    id: 'sixHundredCell',
+    name: '600-Cell',
+    data: SixHundredCellGeometry
   }
 };
 

--- a/src/pipeline/geometryController.ts
+++ b/src/pipeline/geometryController.ts
@@ -1,0 +1,31 @@
+import type { GeometryDescriptor } from '../geometry/types';
+import { getGeometry, listGeometries, type GeometryId } from './geometryCatalog';
+import type { HypercubeCore } from '../core/hypercubeCore';
+
+export class GeometryController {
+  private readonly descriptors: GeometryDescriptor[];
+  private active: GeometryId | null = null;
+
+  constructor(private readonly core: HypercubeCore) {
+    this.descriptors = listGeometries();
+  }
+
+  getAvailableGeometries(): GeometryDescriptor[] {
+    return this.descriptors.slice();
+  }
+
+  getActiveGeometry(): GeometryId | null {
+    return this.active;
+  }
+
+  getDescriptor(id: GeometryId): GeometryDescriptor | undefined {
+    return this.descriptors.find(descriptor => descriptor.id === id);
+  }
+
+  setActiveGeometry(id: GeometryId) {
+    if (this.active === id) return;
+    const geometry = getGeometry(id);
+    this.core.setGeometry(geometry);
+    this.active = id;
+  }
+}

--- a/src/pipeline/haosBridge.test.ts
+++ b/src/pipeline/haosBridge.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it, vi } from 'vitest';
+import { HaosBridge } from './haosBridge';
+import { FocusDirector } from './focusDirector';
+import { RotationBus } from './rotationBus';
+
+const mockFocusDirector = {
+  ingestHint: vi.fn()
+} as unknown as FocusDirector;
+
+describe('HaosBridge', () => {
+  it('dispatches focus profile updates', () => {
+    const bridge = new HaosBridge(mockFocusDirector);
+    const response = bridge.handleRequest({ id: 1, method: 'setFocusProfile', params: { geometry: 'tesseract' } });
+    expect(response.result).toBe('ok');
+  });
+
+  it('returns method not found for unknown calls', () => {
+    const bridge = new HaosBridge(mockFocusDirector);
+    const response = bridge.handleRequest({ id: 2, method: 'unknown' });
+    expect(response.error?.code).toBe(-32601);
+  });
+});

--- a/src/pipeline/haosBridge.ts
+++ b/src/pipeline/haosBridge.ts
@@ -1,0 +1,40 @@
+import type { FocusDirector, FocusHint } from './focusDirector';
+
+export interface JsonRpcRequest {
+  id: string | number;
+  method: string;
+  params?: Record<string, unknown>;
+}
+
+export interface JsonRpcResponse {
+  id: string | number;
+  result?: unknown;
+  error?: { code: number; message: string };
+}
+
+export class HaosBridge {
+  constructor(private readonly focusDirector: FocusDirector) {}
+
+  handleRequest(request: JsonRpcRequest): JsonRpcResponse {
+    try {
+      switch (request.method) {
+        case 'setFocusProfile':
+          this.applyFocus(request.params as FocusHint);
+          return { id: request.id, result: 'ok' };
+        case 'queueRotationScript':
+          return { id: request.id, result: 'queued' };
+        case 'requestSnapshot':
+          return { id: request.id, result: { timestamp: performance.now() } };
+        default:
+          return { id: request.id, error: { code: -32601, message: 'Method not found' } };
+      }
+    } catch (error) {
+      return { id: request.id, error: { code: -32000, message: (error as Error).message } };
+    }
+  }
+
+  private applyFocus(params?: FocusHint) {
+    if (!params) return;
+    this.focusDirector.ingestHint(params);
+  }
+}

--- a/src/pipeline/latencyTracker.test.ts
+++ b/src/pipeline/latencyTracker.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import type { UniformSyncMetrics } from '../core/uniformSyncQueue';
+import { LatencyTracker } from './latencyTracker';
+
+const baseMetrics: UniformSyncMetrics = {
+  enqueued: 0,
+  uploads: 0,
+  skipped: 0,
+  lastUploadTime: 0,
+  lastSnapshotTimestamp: 0,
+  lastUploadLatency: 0
+};
+
+describe('LatencyTracker', () => {
+  it('records uniform and capture latencies without duplicating samples', () => {
+    const tracker = new LatencyTracker(4);
+    tracker.recordUniform({ ...baseMetrics, uploads: 1, lastUploadTime: 10, lastSnapshotTimestamp: 2, lastUploadLatency: 8 });
+    tracker.recordUniform({ ...baseMetrics, uploads: 1, lastUploadTime: 10, lastSnapshotTimestamp: 2, lastUploadLatency: 8 });
+    tracker.recordUniform({ ...baseMetrics, uploads: 2, lastUploadTime: 22, lastSnapshotTimestamp: 5, lastUploadLatency: 17 });
+
+    tracker.recordCapture(5, 25);
+    tracker.recordCapture(5, 30);
+    tracker.recordCapture(10, 32);
+
+    const metrics = tracker.getMetrics();
+    expect(metrics.uniformAvgMs).toBeCloseTo((8 + 17) / 2);
+    expect(metrics.uniformMaxMs).toBeCloseTo(17);
+    expect(metrics.captureAvgMs).toBeCloseTo(((25 - 5) + (32 - 10)) / 2);
+    expect(metrics.captureMaxMs).toBeCloseTo(22);
+  });
+
+  it('tracks encode latency samples', () => {
+    const tracker = new LatencyTracker(3);
+    tracker.recordEncode(4);
+    tracker.recordEncode(6);
+    tracker.recordEncode(8);
+    tracker.recordEncode(10);
+
+    const metrics = tracker.getMetrics();
+    expect(metrics.encodeAvgMs).toBeCloseTo((6 + 8 + 10) / 3);
+    expect(metrics.encodeMaxMs).toBeCloseTo(10);
+  });
+});

--- a/src/pipeline/latencyTracker.ts
+++ b/src/pipeline/latencyTracker.ts
@@ -1,0 +1,105 @@
+import type { UniformSyncMetrics } from '../core/uniformSyncQueue';
+
+interface RollingStats {
+  push(value: number): void;
+  average(): number;
+  max(): number;
+}
+
+class FixedWindowStats implements RollingStats {
+  private readonly values: number[] = [];
+  private total = 0;
+
+  constructor(private readonly windowSize = 32) {}
+
+  push(value: number) {
+    if (!Number.isFinite(value) || value < 0) {
+      return;
+    }
+    this.values.push(value);
+    this.total += value;
+    if (this.values.length > this.windowSize) {
+      const removed = this.values.shift();
+      if (removed !== undefined) {
+        this.total -= removed;
+      }
+    }
+  }
+
+  average(): number {
+    if (this.values.length === 0) {
+      return 0;
+    }
+    return this.total / this.values.length;
+  }
+
+  max(): number {
+    if (this.values.length === 0) {
+      return 0;
+    }
+    return Math.max(...this.values);
+  }
+}
+
+export interface PipelineLatencyMetrics {
+  uniformAvgMs: number;
+  uniformMaxMs: number;
+  captureAvgMs: number;
+  captureMaxMs: number;
+  encodeAvgMs: number;
+  encodeMaxMs: number;
+}
+
+export class LatencyTracker {
+  private readonly uniformStats: RollingStats;
+  private readonly captureStats: RollingStats;
+  private readonly encodeStats: RollingStats;
+  private lastUniformUploads = 0;
+  private lastUniformTime = 0;
+  private lastCaptureTimestamp = 0;
+
+  constructor(windowSize = 32) {
+    this.uniformStats = new FixedWindowStats(windowSize);
+    this.captureStats = new FixedWindowStats(windowSize);
+    this.encodeStats = new FixedWindowStats(windowSize);
+  }
+
+  recordUniform(metrics: UniformSyncMetrics) {
+    if (metrics.uploads === this.lastUniformUploads) {
+      return;
+    }
+    this.lastUniformUploads = metrics.uploads;
+    if (metrics.lastUploadTime === this.lastUniformTime) {
+      return;
+    }
+    this.lastUniformTime = metrics.lastUploadTime;
+    const latency = metrics.lastUploadLatency;
+    if (metrics.lastSnapshotTimestamp > 0 && latency >= 0) {
+      this.uniformStats.push(latency);
+    }
+  }
+
+  recordCapture(snapshotTimestamp: number, captureTime: number) {
+    if (snapshotTimestamp <= this.lastCaptureTimestamp) {
+      return;
+    }
+    this.lastCaptureTimestamp = snapshotTimestamp;
+    const latency = Math.max(0, captureTime - snapshotTimestamp);
+    this.captureStats.push(latency);
+  }
+
+  recordEncode(latencyMs: number) {
+    this.encodeStats.push(latencyMs);
+  }
+
+  getMetrics(): PipelineLatencyMetrics {
+    return {
+      uniformAvgMs: this.uniformStats.average(),
+      uniformMaxMs: this.uniformStats.max(),
+      captureAvgMs: this.captureStats.average(),
+      captureMaxMs: this.captureStats.max(),
+      encodeAvgMs: this.encodeStats.average(),
+      encodeMaxMs: this.encodeStats.max()
+    };
+  }
+}

--- a/src/pipeline/projectionBridge.test.ts
+++ b/src/pipeline/projectionBridge.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { configureProjection } from './projectionBridge';
+import { vec4 } from 'gl-matrix';
+
+describe('ProjectionBridge', () => {
+  it('provides orthographic projection identity', () => {
+    const { project } = configureProjection('orthographic');
+    const input = vec4.fromValues(1, 2, 3, 4);
+    const result = project(input);
+    expect(Array.from(result)).toEqual([1, 2, 3]);
+  });
+
+  it('applies perspective depth scaling', () => {
+    const { project } = configureProjection('perspective', { distance: 5 });
+    const input = vec4.fromValues(1, 1, 1, 1);
+    const result = project(input);
+    expect(result[0]).toBeCloseTo(1 / 4);
+    expect(result[2]).toBeCloseTo(1 / 4);
+  });
+});

--- a/src/pipeline/projectionBridge.ts
+++ b/src/pipeline/projectionBridge.ts
@@ -1,0 +1,73 @@
+import type { vec4, vec3 } from 'gl-matrix';
+import { vec3 as Vec3 } from 'gl-matrix';
+
+export type ProjectionMode = 'perspective' | 'stereographic' | 'orthographic';
+
+export interface ProjectionParameters {
+  distance?: number;
+  focalLength?: number;
+  stereographicScale?: number;
+}
+
+export interface ProjectionConfig {
+  mode: ProjectionMode;
+  shaderSnippet: string;
+  project: (input: vec4) => vec3;
+}
+
+export function configureProjection(mode: ProjectionMode, parameters: ProjectionParameters = {}): ProjectionConfig {
+  switch (mode) {
+    case 'perspective':
+      return {
+        mode,
+        shaderSnippet: perspectiveSnippet(parameters.distance ?? 3.0),
+        project: vector => projectPerspective(vector, parameters.distance ?? 3.0)
+      };
+    case 'stereographic':
+      return {
+        mode,
+        shaderSnippet: stereographicSnippet(parameters.stereographicScale ?? 1.0),
+        project: vector => projectStereographic(vector, parameters.stereographicScale ?? 1.0)
+      };
+    case 'orthographic':
+    default:
+      return {
+        mode: 'orthographic',
+        shaderSnippet: orthographicSnippet(),
+        project: vector => Vec3.fromValues(vector[0], vector[1], vector[2])
+      };
+  }
+}
+
+function perspectiveSnippet(distance: number): string {
+  return `
+vec3 project4Dto3D(vec4 v) {
+  float depth = max(${distance.toFixed(3)} - v.w, 0.1);
+  return v.xyz / depth;
+}`.trim();
+}
+
+function stereographicSnippet(scale: number): string {
+  return `
+vec3 project4Dto3D(vec4 v) {
+  float denom = max(${scale.toFixed(3)} - v.w, 0.1);
+  return v.xyz / denom;
+}`.trim();
+}
+
+function orthographicSnippet(): string {
+  return `
+vec3 project4Dto3D(vec4 v) {
+  return v.xyz;
+}`.trim();
+}
+
+function projectPerspective(vector: vec4, distance: number): vec3 {
+  const depth = Math.max(distance - vector[3], 0.1);
+  return Vec3.fromValues(vector[0] / depth, vector[1] / depth, vector[2] / depth);
+}
+
+function projectStereographic(vector: vec4, scale: number): vec3 {
+  const denom = Math.max(scale - vector[3], 0.1);
+  return Vec3.fromValues(vector[0] / denom, vector[1] / denom, vector[2] / denom);
+}

--- a/src/pipeline/pspStream.test.ts
+++ b/src/pipeline/pspStream.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { LocalPspStream } from './pspStream';
+
+const mockBlob = new Blob(['test'], { type: 'text/plain' });
+
+describe('LocalPspStream', () => {
+  it('notifies subscribers of frames', async () => {
+    const stream = new LocalPspStream();
+    let received = 0;
+    stream.subscribe(frame => {
+      received += frame.metadata.timestamp;
+    });
+    stream.publish({
+      blob: mockBlob,
+      metadata: { timestamp: 2, rotationAngles: [0, 0, 0, 0, 0, 0] }
+    });
+    expect(received).toBe(2);
+  });
+});

--- a/src/pipeline/pspStream.ts
+++ b/src/pipeline/pspStream.ts
@@ -1,0 +1,25 @@
+import type { EncodedFrame } from './datasetExport';
+
+export interface PspSubscriber {
+  (frame: EncodedFrame): void;
+}
+
+export interface PspStream {
+  subscribe(listener: PspSubscriber): () => void;
+  publish(frame: EncodedFrame): void;
+}
+
+export class LocalPspStream implements PspStream {
+  private readonly listeners = new Set<PspSubscriber>();
+
+  subscribe(listener: PspSubscriber): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  publish(frame: EncodedFrame): void {
+    for (const listener of this.listeners) {
+      listener(frame);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a "Manifest updated" row to the control panel telemetry block
- format manifest timestamps relative to now so operators can see freshness at a glance
- document the manifest telemetry session in the rebuild progress log

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68d5c4f267208329a9714855d5f3d9b1