### PR TITLE
Optimize dual quaternion helpers for reusable buffers

### DIFF
--- a/PPP_COMPLETE_SYSTEM_DOCUMENTATION.md
+++ b/PPP_COMPLETE_SYSTEM_DOCUMENTATION.md
@@ -1,5 +1,14 @@
 # PPP Complete System Documentation v4.0
 
+> **Implementation Status Update (2024)**
+> The production code for HypercubeCore, parserator, and the surrounding telemetry/export pipeline now lives in `src/` as TypeScript modules. When this document references conceptual components (e.g., `HypercubeCore.js`, `KerbelizedParserator.js`, `HOASBridge.js`), map them to the maintained files:
+> - Rendering & uniforms → `src/core/hypercubeCore.ts`, `src/core/rotationUniforms.ts`, `src/core/uberShaderBuilder.ts`
+> - Parserator & extruments → `src/ingestion/parserator.ts`, `src/ingestion/profiles.ts`, `src/ingestion/extrumentHub.ts`
+> - Pipeline & orchestration → `src/pipeline/haosBridge.ts`, `src/pipeline/contextScheduler.ts`, `src/pipeline/datasetExport.ts`, and companions
+> - Operator surface → `index.html`, `src/main.ts`
+>
+> Earlier sections remain valuable as conceptual framing, but the module names above represent the current system and should be used for development, testing, and documentation updates.
+
 ## Executive Overview: Polytopal Projection Processing Ecosystem
 
 The Polytopal Projection Processing (PPP) paradigm represents a fundamental breakthrough in computational architecture, transforming high-dimensional data processing from sequential bottlenecks to parallel geometric computation. This comprehensive documentation covers all aspects of the system from mathematical foundations through commercial applications.

--- a/PPP_TECHNICAL_ARCHITECTURE_SPECIFICATION.md
+++ b/PPP_TECHNICAL_ARCHITECTURE_SPECIFICATION.md
@@ -1,5 +1,7 @@
 # PPP Technical Architecture Specification v3.0
 
+> **Alignment Note (2024):** Map all component names in this specification to the TypeScript modules inside `src/`. Rendering is implemented by `src/core/hypercubeCore.ts` and companions, ingestion by `src/ingestion/`, and orchestration/telemetry by `src/pipeline/`.
+
 ## Complete System Documentation for Polytopal Projection Processing
 
 ---

--- a/architectural_vision.md
+++ b/architectural_vision.md
@@ -1,53 +1,62 @@
-# Architectural Vision for Visualization Kernel and PMK
+# Architectural Vision for HypercubeCore & Parserator Platform
 
-This document outlines the refined architectural vision for the Visualization Kernel, Parserator Micro-Kernel (PMK), and associated systems, based on discussions on [Date of discussion - placeholder].
+This revision brings the architectural notes back in sync with the current TypeScript codebase that powers the HypercubeCore SO(4) renderer, parserator ingestion stack, and orchestration services. It captures how the real modules under `src/` collaborate today and how the staged rebuild plan extends them.
 
-## Core Architectural Principles: Distributed Intelligence
+## System Pillars
 
-The system is envisioned as a distributed intelligence architecture with two primary tiers:
+### 1. HypercubeCore Rendering Kernel
+- **Location:** `src/core/`
+- **Key Modules:**
+  - `hypercubeCore.ts` – owns the WebGL2 context, shader program lifecycle, uniform buffer binding, and frame capture entry points.
+  - `rotationUniforms.ts` – defines the canonical `RotationAngles`/`RotationSnapshot` types plus the std140 uniform buffer contract.
+  - `sixPlaneOrbit.ts` & `uberShaderBuilder.ts` – generate sequential rotation matrices and assemble shader sources that consume the uniform block.
+- **Responsibilities:**
+  - Maintain deterministic parity between sequential-matrix, dual-quaternion, and GPU uniform uploads.
+  - Expose capture hooks (`captureFrame`, `setUniformUploadListener`) that feed dataset export and telemetry systems.
+  - Provide geometry registration (`setGeometry`) that keeps the active polychoron resident on the GPU for all downstream stages.
 
-1.  **Localized AI/Edge Component (Kerbalized Parserator):**
-    *   **Nature:** A compact, high-speed AI module designed to run on edge devices or in close proximity to a multitude of sensors and entities (potentially hundreds).
-    *   **Primary Functions:**
-        *   **Efficient Parsing:** Its core task is to parse incoming data streams from sensors using the `KerbelizedParserator` engine.
-        *   **Sensor Interaction & Local Tuning:** Directly interacts with sensors. This includes adjusting sensor parameters or focus based on directives from the Cloud AI.
-        *   **Adaptive Schema Management:** Utilizes an `AdaptiveSchemaGraph` for its parsing logic. This graph is adapted locally based on parsing performance and directives from the Cloud AI.
-    *   **Characteristics:** Optimized for low latency and real-time processing.
+### 2. Parserator Micro-Kernel & Extrument Mapping
+- **Location:** `src/ingestion/`
+- **Key Modules:**
+  - `parserator.ts` – runtime-configurable ingestion kernel with profile swapping, confidence-floor tuning, and disposable preprocessors.
+  - `profiles.ts` – registry of named calibration profiles used by the console and manifest persistence.
+  - `extrumentHub.ts` & `midiExtrument.ts` – adapter hub with snapshot normalisation, MIDI broadcast helpers, and error isolation per adapter.
+  - `replayHarness.ts` – deterministic playback utility for captured rotation streams.
+- **Responsibilities:**
+  - Convert IMU/external instrument packets into `RotationSnapshot` updates for the rotation bus.
+  - Persist calibration context (profile, preprocessors, thresholds) for deterministic rehydration.
+  - Provide safe broadcast paths to MIDI or other extruments while maintaining snapshot confidence guarantees.
 
-2.  **Cloud AI Orchestrator:**
-    *   **Nature:** A more powerful, higher-level AI system residing in the cloud, connected to the localized AI components via a high-bandwidth, low-latency network (e.g., 6G).
-    *   **Primary Functions:**
-        *   **Strategic Direction:** Provides overall strategic goals and direction to the distributed fleet of localized AIs.
-        *   **Focus & Sensor Tuning Commands:** Instructs local AIs on what data to prioritize or how to configure their attached sensors (e.g., "for sensor X, focus on parameter Y under conditions Z").
-        *   **Schema Adaptation Guidance:** Sends directives that influence how the local `AdaptiveSchemaGraph` should evolve or which parsing strategies to employ.
-        *   **Global Error Correction & Optimization:** Monitors overall system performance and provides corrective feedback or updated models to the local AIs.
-        *   **Data Topology Analysis (Implied):** Likely analyzes aggregated data or patterns from local AIs to make strategic decisions.
+### 3. Pipeline, Telemetry, and Dataset Services
+- **Location:** `src/pipeline/`
+- **Key Modules:**
+  - `datasetExport.ts`, `datasetWorker.ts`, `frameEncoding.ts` – PSP capture/export orchestrators with worker offload and latency tracking.
+  - `datasetManifest.ts`, `datasetTypes.ts` – manifest builder with deterministic naming, hydration, and latency envelope aggregation.
+  - `telemetryLoom.ts`, `confidenceTrend.ts`, `latencyTracker.ts` – runtime analytics surfaces for control-panel telemetry and manifest enrichment.
+  - `contextScheduler.ts`, `focusDirector.ts`, `haosBridge.ts`, `projectionBridge.ts` – orchestration utilities described in the rebuild blueprint stages.
+- **Responsibilities:**
+  - Sample pipeline latency (sensor→uniform→capture→encode) and expose live/aggregated metrics.
+  - Persist manifests, telemetry snapshots, and calibration metadata across sessions.
+  - Drive PSP exports via worker-backed pipelines without starving the render loop.
 
-## Key Components and Their Roles (Refined Understanding):
+### 4. Control Panel & Operator Experience
+- **Location:** `index.html`, `src/main.ts`
+- **Key Features:**
+  - Parameter console with sections for geometry selection, rotation playback, parserator calibration, extrument status, and dataset telemetry.
+  - Hydration/persistence wiring for manifests, telemetry loom, confidence trends, and extrument adapters.
+  - Event routing that synchronises UI intent with HypercubeCore, parserator, and export services.
 
-*   **`KerbelizedParserator.js`:** The engine for the Localized AI. Contains the parsing logic and interacts with its internal components.
-*   **`AdaptiveSchemaGraph.js`:** Resides within each `KerbelizedParserator`. It's the dynamic knowledge structure used for parsing. Its adaptation is driven by local parsing results *and* by directives/tuning parameters from the Cloud AI.
-*   **`BayesianFocusOptimizer.js`:** Likely part of the `KerbelizedParserator`. It helps the local AI tune its focus, but its optimization strategy or target parameters can be influenced or set by the Cloud AI.
-*   **`PMKDataAdapter.js`:** Facilitates the translation of data from the `KerbelizedParserator`'s output into a format suitable for the `VisualizerController`. It might also play a role in formatting data to be sent to the Cloud AI.
-*   **`VisualizerController.js` (and `HypercubeCore.js`):** Provides the visualization capabilities. This could be used locally (e.g., for an edge device's diagnostic interface) or to send visual summaries/snapshots to the Cloud AI or a central monitoring dashboard.
-*   **`HOASBridge.js` (Higher Order Abstraction System Bridge):** This component is crucial for the communication between the Cloud AI Orchestrator and the Localized AI(s). It would:
-    *   Translate high-level strategic commands from the Cloud AI into specific configurations, parameters, or operational directives for `KerbelizedParserator` and its sub-components.
-    *   Relay status, summaries, or salient data from the Local AI(s) back to the Cloud AI.
-*   **`PPPProjector.js` & `TimestampedThoughtBuffer.js`:** These components remain important for advanced parsing capabilities within the `KerbelizedParserator`, helping with tasks like resolving ambiguity or maintaining context. Their operation could also be influenced by Cloud AI directives (e.g., adjusting buffer sizes, projection strategies).
+## Cloud Orchestration & HAOS Alignment
+- **HAOS Bridge (`src/pipeline/haosBridge.ts`):** Defines the contract for higher-order automation to request captures, adjust focus targets, and subscribe to telemetry envelopes.
+- **Focus Director (`src/pipeline/focusDirector.ts`):** Uses telemetry and HAOS cues to prioritise geometry/ingestion tasks during replay or live sessions.
+- **Context Scheduler (`src/pipeline/contextScheduler.ts`):** Coordinates worker pools, uniform uploads, and dataset flush cadence to honour latency budgets defined in the rebuild blueprint.
 
-## Adaptive Schema Intelligence (ASI) - Clarified
+These modules collectively fulfil the distributed-intelligence goals outlined for edge parserator nodes and higher-level orchestration: the parserator stack surfaces calibrated snapshots, HypercubeCore renders deterministic frames, and the pipeline services record artefacts/telemetry for HAOS or external consumers.
 
-ASI is achieved through the interplay of:
-1.  The local `KerbelizedParserator` adapting its `AdaptiveSchemaGraph` based on its direct parsing experiences.
-2.  The Cloud AI Orchestrator providing higher-level guidance, tuning parameters, and strategic objectives that shape the local adaptation process and sensor interaction.
+## Development Track Alignment
+- **Stage 0–1 (Core Kernel Rebuild):** Reuse `RotationUniformBuffer`, `HypercubeCore`, and `parserator` core while establishing parity tests across sequential, matrix, and dual-quaternion paths.
+- **Stage 2 (Geometry & Capture):** Keep geometry uploads GPU-resident through `setGeometry` and validate capture via `captureFrame` against staged datasets.
+- **Stage 3 (Parserator Service & Extruments):** Expand `extrumentHub` adapters and HAOS bridge hooks to support external instruments and replay harness integration.
+- **Stage 4–6 (Export, Telemetry, Automation):** Leverage dataset export worker, manifest persistence, telemetry loom, and HAOS bridge to satisfy automation, performance, and orchestration checkpoints.
 
-The Local AI does not expose its raw `AdaptiveSchemaGraph` for arbitrary external systems to directly parse and control themselves. Instead, control and major tuning are mediated by the Cloud AI, which then directs the Local AI.
-
-## Implications for Development:
-
-*   The interface and communication protocol between the Cloud AI and the Local AI (likely via `HOASBridge`) becomes a critical design point.
-*   `KerbelizedParserator` and its components need to be configurable and controllable by these external directives.
-*   The `AdaptiveSchemaGraph` needs mechanisms to incorporate guidance from the Cloud AI into its adaptation logic.
-*   Visualization may serve multiple purposes: local diagnostics, data summaries for the Cloud AI, and potentially real-time topological displays for human oversight.
-
-This refined vision emphasizes a hierarchical control system, leveraging fast local parsing with strategic cloud-based oversight and optimization.
+All future planning documents should reference these concrete modules and the staged rebuild blueprint to stay aligned with the production TypeScript system.

--- a/docs/rebuild-log.md
+++ b/docs/rebuild-log.md
@@ -1,0 +1,184 @@
+# Rebuild Blueprint Progress Log
+
+This log captures the follow-on work after the “Implement staged rebuild blueprint” baseline. Each entry records what was added in this session and why that piece matters for the staged HypercubeCore MVP.
+
+## Session – Telemetry & Frame Capture Bring-Up
+
+### What changed
+- **WebGL frame capture** (`HypercubeCore.captureFrame`, `flipPixelsVertically`) – expose a deterministic pixel readback so downstream services can pull actual render output instead of placeholder pixels.
+- **Dataset export metrics** (`DatasetExportService`) – track pending queue depth, total encoded frames, and last export format while flushing frames through the PSP stream.
+- **Control-panel telemetry** (`index.html`, `main.ts`) – surface uniform upload/skipped counts and dataset export metrics next to the rotation controls, keeping the operator aware of buffer health.
+- **Synthetic capture wiring** (`main.ts`) – replace the stubbed 1×1 pixel export with real captures throttled by queue depth and broadcast them via `LocalPspStream`.
+
+### Why these pieces matter
+- The **frame capture path** proves that Stage 2 geometry uploads can feed Stage 4 dataset export without leaving the GPU pipeline—critical for PSP archival and ML consumers.
+- **Dataset metrics** let us validate the UniformSync queue contract (exactly one upload per frame) and ensure capture/export doesn’t fall behind during automated or sensor-driven runs.
+- **UI telemetry** provides immediate operator feedback: if skips rise or pending frames spike, we know to adjust ingestion cadence before confidence drops.
+- **Real PSP captures** mean every rotation snapshot now carries a verifiable visual, keeping replay harnesses and external extruments in sync with the actual render output.
+
+### Next checkpoints
+- Thread the capture path through the dataset exporter worker once the Web Worker harness lands (Stage 4).
+- Extend telemetry with rolling latency stats (sensor → uniform upload → capture) to satisfy Stage 6 performance budgets.
+
+## Session – Worker Export Harness & Latency Telemetry
+
+### What changed
+- **Dataset export worker** (`datasetWorker.ts`, `DatasetExportService`) – spin up a dedicated encoder worker when available, track per-frame encode latency, and retain the JSON fallback for deterministic Node/Vitest runs.
+- **Pipeline latency tracker** (`LatencyTracker`) – capture rolling averages/maxima for sensor→uniform, uniform→capture, and encode phases, wiring the telemetry into the control panel for real-time monitoring.
+- **UI telemetry expansion** (`index.html`, `main.ts`) – surface uniform/capture/encode latency readouts plus last export format so operators can correlate queue depth with timing budgets.
+
+### Why these pieces matter
+- The **worker harness** keeps Stage 4 PSP exports off the main thread, preventing encode spikes from starving animation or sensor ingestion.
+- **Latency telemetry** closes the Stage 6 gap by quantifying the end-to-end pipeline budget, highlighting regressions long before they impact HAOS orchestration or ML taps.
+- The **control-panel readouts** give immediate feedback during live sessions, making it easier to tune parserator gains or dataset flush cadence when pending frames creep up.
+
+### Next checkpoints
+- Promote the worker harness into a reusable Web Worker pool once Stage 5 inference taps start sharing GPU time.
+- Record sensor-to-export latency envelopes alongside encoded frames to feed Stage 6 performance regression tests.
+
+## Session – Sensor→Export Latency Envelopes
+
+### What changed
+- **Uniform upload callbacks** (`HypercubeCore.setUniformUploadListener`) – expose a hook after each std140 upload so the main loop can align capture and PSP export with the exact snapshot that reached the GPU.
+- **Capture-triggered exports** (`main.ts`) – throttle capture inside the uniform callback, record capture latency, and attach uniform/capture timings to every queued frame before PSP export.
+- **Encode annotations** (`DatasetExportService`) – persist encode-complete timestamps and total pipeline latency inside each frame’s metadata, regardless of whether encoding happens inline or via the worker.
+- **Latency-aware metadata** (`datasetTypes.ts`, tests) – formalise a `PipelineLatencyEnvelope` contract and cover the fallback/worker paths so regressions surface during CI.
+
+### Why these pieces matter
+- **Deterministic envelopes** ensure Stage 6 tooling can assert sensor→uniform→capture→encode budgets directly from dataset artifacts instead of relying on external logs.
+- **Render-synchronised capture** keeps PSP snapshots aligned with the rotation state actually presented to the viewer, avoiding off-by-one uniform artefacts in downstream training data.
+- **Test coverage** guards against future refactors dropping latency timestamps, giving the rebuild blueprint a verified telemetry contract to build upon.
+
+### Next checkpoints
+- Persist latency envelopes alongside dataset manifests so replay harnesses can compare live runs against recorded totals.
+- Expose histogram/percentile views of the envelope metrics in the control panel for Stage 6 operator dashboards.
+
+## Session – Dataset Manifest Persistence
+
+### What changed
+- **Dataset manifest builder** (`datasetManifest.ts`, tests) – generate deterministic asset names, retain per-frame latency envelopes, and compute aggregate statistics with optional rehydration from previous sessions.
+- **Local storage persistence** (`main.ts`) – hydrate the manifest on load, append entries as PSP exports flush, and guard persistence with error logging when storage is unavailable.
+- **Control-panel telemetry** (`index.html`, `main.ts`) – surface manifest frame counts and p95 latency so operators can monitor archival coverage alongside live export metrics.
+
+### Why these pieces matter
+- The **builder** gives Stage 4+ pipelines a deterministic manifest contract so downstream tooling can reconcile encoded assets with their latency envelopes and rotation snapshots.
+- **Persistence** means operators can stop and resume sessions without losing manifest continuity, satisfying the rebuild blueprint’s requirement for deterministic dataset bookkeeping.
+- The **UI telemetry** closes the loop by exposing archival health directly in the control panel, enabling quick validation that latency percentiles stay within Stage 6 performance budgets.
+
+### Next checkpoints
+- Add manifest export/download affordances so recorded sessions can be archived or shared outside the browser sandbox.
+- Thread manifest statistics into the rebuild telemetry loom once percentile visualisations ship in Stage 6.
+
+## Session – Manifest Export & Archive Controls
+
+### What changed
+- **Manifest filename helper** (`createManifestDownloadName`) – normalises manifest IDs and stamps the latest update time to produce portable, deterministic archive names.
+- **Control-panel download action** (`index.html`, `main.ts`) – adds a dedicated button that serialises the current manifest, disables itself when empty, and streams a JSON download for archival.
+- **Test coverage** (`datasetManifest.test.ts`) – freezes system time to assert download filenames stay deterministic, preventing regressions in the archive contract.
+
+### Why these pieces matter
+- **Deterministic filenames** simplify reconciliation between local archives and persisted manifests, letting operators match downloads to on-device sessions at a glance.
+- **Inline download control** removes the need for devtools hacks when exporting manifests, ensuring Stage 4 dataset work can be shared or backed up immediately after capture.
+- **Tests** guarantee that future refactors keep filenames stable, protecting downstream automation that expects timestamped manifest artefacts.
+
+### Next checkpoints
+- Surface manifest last-updated timestamps directly in the control panel to signal when new frames are ready for export.
+- Bundle PSP frame batches with the manifest download so a single action captures both metadata and imagery for offline review.
+
+## Session – Parserator Calibration Controls
+
+### What changed
+- **Runtime mapping updates** (`parserator.ts`) – allow parserator instances to swap plane-mapping profiles and raise/lower their confidence floor without re-instantiation, keeping calibration live during sessions.
+- **Preprocessor lifecycle** (`parserator.ts`) – return disposal handles when registering preprocessors so temporary filters (e.g., gravity isolation) can be removed cleanly.
+- **Validation tests** (`parserator.test.ts`) – cover preprocessor ordering, profile switching, gravity isolation, and dynamic confidence floors to lock in the new behaviour.
+
+### Why these pieces matter
+- Live **profile switching** supports the rebuild plan’s Stage 3 parserator service, letting operators test alternate IMU mappings or external “extrument” adapters mid-run.
+- **Confidence floor tuning** keeps the rotation bus reliable when sensor noise changes, ensuring downstream uniform queues maintain minimum certainty without restarting the pipeline.
+- **Disposable preprocessors** simplify adaptive filtering—temporary smoothing or isolation filters can be toggled as telemetry warrants.
+- The **test suite** guards the calibration APIs so future refactors keep parserator tooling deterministic and composable for rebuild checkpoints.
+
+### Next checkpoints
+- Surface active profile metadata in the control panel and expose quick toggles for common calibration profiles.
+- Persist custom confidence floors and preprocessor stacks alongside dataset manifests so replay harnesses reproduce exact ingestion conditions.
+
+## Session – Parserator Console & Ingestion Persistence
+
+### What changed
+- **Control panel telemetry** (`index.html`, `main.ts`) – surfaced the active parserator profile, confidence floor, and enabled preprocessors with live selectors for quick calibration during capture sessions.
+- **Profile registry expansion** (`profiles.ts`, tests) – added high-gain and smoothing presets plus lookup utilities so UI controls and automation can target named profiles.
+- **Manifest ingestion metadata** (`datasetManifest.ts`, tests) – persisted the active profile, confidence floor, and preprocessor stack inside dataset manifests, keeping capture conditions reproducible across sessions.
+- **Parserator introspection** (`parserator.ts`, tests) – exposed profile/confidence getters and deterministic preprocessor IDs so the UI and manifest writer can track live calibration state.
+
+### Why these pieces matter
+- **Inline visibility** keeps operators aware of the ingestion stack feeding the rotation bus, enabling rapid comparisons between presets without diving into code.
+- **Persisted calibration** ensures replay harnesses and downstream ML consumers can rehydrate the exact parserator configuration alongside captured frames, satisfying the rebuild blueprint’s determinism goals.
+- **Named profiles and preprocessors** provide a stable contract for future extrument adapters and parserator microservices to request or advertise calibration presets.
+
+### Next checkpoints
+- Persist telemetry loom snapshots alongside dataset manifests so offline exports retain calibration timelines.
+- Visualise histogram trends over time (sparklines or rolling windows) to highlight confidence regressions during capture.
+
+## Session – Parserator Telemetry Loom & Confidence Histograms
+
+### What changed
+- **Telemetry loom** (`telemetryLoom.ts`, `main.ts`, `index.html`) – introduced a bounded event log rendered in the control panel that records parserator profile swaps, confidence adjustments, and preprocessor toggles with timestamps and metadata.
+- **Manifest confidence analytics** (`datasetManifest.ts`, tests) – tracked per-frame confidence, aggregated histograms in manifest statistics, and surfaced high-confidence coverage percentages in the UI.
+- **Metadata propagation** (`datasetExport.ts`, `main.ts`) – attached rotation snapshot confidence to exported frame metadata so dataset manifests and downstream tooling can reason about ingestion certainty.
+
+### Why these pieces matter
+- The **telemetry loom** makes calibration tweaks auditable in real time, giving operators a rolling history when comparing presets or debugging ingestion drift.
+- **Confidence histograms** extend dataset manifests beyond latency metrics, enabling replay harnesses and QA tooling to quantify how much of a session met target confidence thresholds.
+- By **persisting snapshot confidence** with each frame, exported datasets carry enough context for ML consumers to weight samples or filter out low-certainty captures without external logs.
+
+### Next checkpoints
+- Persist telemetry loom snapshots alongside dataset manifests so offline exports retain calibration timelines.
+- Visualise histogram trends over time (sparklines or rolling windows) to highlight confidence regressions during capture.
+
+## Session – Manifest Update Signals & Confidence Trends
+
+### What changed
+- **Confidence trend store** (`confidenceTrend.ts`, tests) – added a bounded, persistent sparkline buffer that records the high-confidence ratio every time the manifest updates.
+- **Control-panel signals** (`index.html`, `main.ts`) – surfaced the manifest last-updated timestamp with relative time formatting, drew a live confidence sparkline, and persisted the trend alongside the manifest.
+- **Trend rendering utility** (`main.ts`) – normalized canvas rendering with DPI-aware drawing, 90% reference lines, and graceful empty-state messaging.
+
+### Why these pieces matter
+- The **confidence trend** highlights regression patterns that a single histogram snapshot obscures, warning operators when coverage begins to slip mid-session.
+- **Last-updated timestamps** make it obvious when fresh frames hit disk, tightening the loop between capture, export, and operator review.
+- Persisting the **sparkline history** means restarts keep trend context, so follow-up analysis can correlate drops with telemetry events captured in previous sessions.
+
+### Next checkpoints
+- Thread the confidence trend into manifest downloads so offline analysis retains sparkline samples.
+- Overlay parserator confidence-floor changes on the sparkline to correlate configuration shifts with confidence coverage swings.
+
+## Session – Confidence Trend Archival & Manifest Hydration
+
+### What changed
+- **Manifest confidence trend snapshots** (`datasetManifest.ts`, `datasetManifest.test.ts`) – manifest builder now sanitises and persists the sparkline samples from the control panel, ensuring downloads include the historical high-confidence ratios.
+- **Control-panel persistence** (`main.ts`) – hydrates trend state from stored manifests, updates the builder before telemetry reads, and clears stale localStorage entries when the trend resets.
+- **System-status docs** (`docs/system-status.md`) – QA checklist now calls out the archived `confidenceTrend` payload so operators verify exports capture the sparkline history.
+
+### Why these pieces matter
+- Capturing the **confidence trend inside manifests** lets offline analysts correlate sparkline swings with telemetry logs without relying on browser storage.
+- **Hydrating from manifest data** keeps the sparkline consistent across reloads or when manifests travel between machines, reinforcing the rebuild blueprint’s determinism goals.
+- Documenting the **QA expectation** prevents the archived trend from regressing silently during future refactors.
+
+### Next checkpoints
+- Attach parserator calibration annotations to each trend sample so sparkline inflections can be traced back to profile or confidence-floor changes.
+- Include confidence trend payloads alongside PSP frame bundles to keep visual, telemetry, and confidence data aligned in offline review kits.
+
+## Session – Confidence Trend Calibration Annotations
+
+### What changed
+- **Annotated trend samples** (`confidenceTrend.ts`, tests) – sparkline samples now record the active parserator profile, confidence floor, and preprocessor list so each point carries calibration context.
+- **Manifest persistence** (`datasetManifest.ts`, tests) – dataset manifests clone and hydrate the annotated sparkline, guaranteeing offline reviewers can see which calibration produced each confidence datapoint.
+- **Control-panel integration** (`main.ts`) – manifest updates feed the annotated trend with the current parserator configuration and avoid persisting empty buffers.
+
+### Why these pieces matter
+- Calibration shifts are now captured alongside confidence swings, letting QA correlate sparkline inflections with profile swaps or confidence-floor adjustments without manual note keeping.
+- Annotated manifests give downstream tooling enough metadata to segment datasets by calibration regime, supporting targeted analysis or retraining.
+- The control-panel persistence loop keeps localStorage and manifest snapshots aligned, preventing stale trend metadata from leaking into QA runs.
+
+### Next checkpoints
+- Overlay parserator calibration change markers on the sparkline visualization to highlight when annotations shift in real time.
+- Bundle confidence trend annotations with PSP frame exports so playback tools can display calibration context during review.

--- a/docs/refine-rotor-pipeline-branch-report.md
+++ b/docs/refine-rotor-pipeline-branch-report.md
@@ -1,0 +1,61 @@
+# Refine SO(4) Rotor Pipeline & Extrument Mapping – Branch Report
+
+This report documents the impact of the "Refine SO(4) Rotor Pipeline and Extrument Mapping" branch and
+identifies how its outcomes shape the staged rebuild blueprint. The branch consolidated the six-plane
+rotation kernel, tightened the uniform-buffer contract, and formalised the path from sensor input to
+external "extruments" (external instruments).
+
+## Purpose & Scope
+
+- **Rotation kernel fidelity:** Align matrix, sequential, and dual-quaternion paths around a single
+  `RotationAngles` ordering so every subsystem reads identical SO(4) snapshots.
+- **Uniform-buffer contract:** Centralise std140 buffer allocation and updates through
+  `RotationUniformBuffer` to prevent diverging uniforms across render programs.
+- **Extrument integration:** Normalise IMU snapshots and expose adapter plumbing so external devices or
+  controllers can publish/subscribe to rotation updates without bespoke wiring.
+
+## Code Differences & Stability Impact
+
+| Area | Refinement | Stability Outcome |
+| --- | --- | --- |
+| Rotation math | Shared helpers for sequential rotations, matrix construction, and dual-quaternion composition reuse the same plane ordering. | Eliminates drift between ingestion, CPU checks, and GPU shaders during long sessions. |
+| Uniform updates | `RotationUniformBuffer` owns buffer layout, binding, and updates. | Keeps every render path in lockstep with deterministic std140 uploads. |
+| External mapping | IMU packets pass through calibrated gains, confidence scoring, and adapter registration in `ExtrumentHub`. | Supports multiple adapters without cross-talk while preserving deterministic telemetry. |
+
+The consolidation improved both maintainability and runtime determinism; tests cover rotation energy,
+sequential parity, and adapter broadcasts to guard future refactors.
+
+## Experimental & Integrative Capabilities
+
+- **Sensor-driven instrumentation:** Calibrated gain matrices translate gyro/accel input into spatial and
+  hyperspatial planes, making it simple to onboard new IMU devices or MIDI controllers.
+- **Audio/visual weaving:** Existing shader/audio bridges reuse the refined uniform bus so six-plane
+  snapshots can drive reactive visuals and external synths simultaneously.
+- **Operator tooling:** Console panels expose geometry, ingestion, and telemetry controls, letting QA teams
+  exercise the refined pipeline while observing latency, confidence, and manifest metrics.
+
+## Commit-Level Highlights
+
+1. **Rotor pipeline optimisation** – refactored sequential rotation helpers, shared plane ordering, and
+   dual-quaternion composition to guarantee parity across math paths.
+2. **Extrument mapping integration** – introduced the `ExtrumentHub`, MIDI adapter, and snapshot
+   normalisation so multiple external instruments can subscribe to the rotation bus.
+3. **Documentation alignment** – updated architecture and rebuild references to match the refined kernel,
+   manifest workflow, and external adapter contracts.
+
+## Recommended Continuation Strategy
+
+The "HypercubeCore – CPE Rebuild Blueprint" is the strongest platform for continued development. It reuses
+this branch's deterministic kernel while delivering a staged MVP:
+
+1. **Stages 0–1:** Stand up the trimmed `/core` layout, reuse the refined rotation helpers, and add parity
+   tests that compare sequential, matrix, and dual-quaternion paths across randomised inputs.
+2. **Stage 2:** Reintroduce the minimal geometry catalog, keeping meshes GPU-resident and feeding them
+   directly from `RotationUniformBuffer` uploads.
+3. **Stage 3:** Extend the extrument mapper into the parserator service, layering profile presets and a
+   deterministic uniform sync queue to guarantee one snapshot per frame.
+4. **Stages 4–6:** Layer projection bridging, dataset export, HAOS orchestration, and CI tooling on top of
+   the stable rotation bus, using the manifest and telemetry contracts validated in this branch.
+
+Following this plan yields a lean yet extensible MVP while preserving compatibility with external
+instruments, dataset pipelines, and future HAOS integrations.

--- a/docs/refine-rotor-pipeline-continuation.md
+++ b/docs/refine-rotor-pipeline-continuation.md
@@ -1,0 +1,41 @@
+# Refine SO(4) Rotor Pipeline: Continuation Playbook
+
+This playbook expands on the branch report and rebuild notes so the refined SO(4) pipeline and extrument mapping work can flow directly into a clean-room MVP. Use it alongside `docs/rebuild-log.md`, `docs/rotor-pipeline-overview.md`, and the staged blueprint when planning next iterations.
+
+## Snapshot of the Refined Foundations
+
+- **Deterministic rotation kernel** – `rotationMatrixFromAngles`, `applySequentialRotations`, and the dual-quaternion helpers consume identical `RotationAngles` ordering and epsilon tolerances, guaranteeing matrix and quaternion parity for all six planes.
+- **Uniform-buffer contract** – `RotationUniformBuffer.update` is the single entry point for GPU-bound angles; it owns std140 layout, binding, and dirty-state tracking so every pass reads the same snapshot.
+- **Extrument mapping layer** – `ExtrumentHub`, `normalizeSnapshot`, and the MIDI adapter translate rotation snapshots into bounded magnitudes and controller-safe signals with connection lifecycle guards.
+- **Dataset + telemetry plumbing** – manifest builders, latency envelopes, telemetry looms, and confidence trends already persist to storage and hydrate from manifests, giving deterministic archives for regression and replay.
+
+## Alignment Checklist
+
+Use this quick sweep before merging further work:
+
+1. **Math parity tests** – Run the dual-quaternion, sequential rotation, and energy unit suites; parity must hold within documented tolerances before any feature work branches off.
+2. **Uniform hydration sanity** – Load a dataset manifest in the control panel and verify uniform uploads are sourced from the rehydrated snapshot, not ad-hoc controllers.
+3. **Extrument guard rails** – With MIDI disabled, ensure the hub idles without throwing; with MIDI enabled, validate connection prompts, payload summaries, and cleanup paths.
+4. **Telemetry persistence** – Flush a dataset, reload, and confirm telemetry timelines, manifest stats, and confidence sparklines all restore without mutation.
+5. **Documentation pointers** – Confirm `system-status.md`, the rebuild log, and the rotor pipeline overview reference the same module names and file paths touched by recent commits.
+
+## Clean-Room MVP Roadmap (Stages 0–6)
+
+| Stage | Focus | Key Actions | Carry-over Modules |
+|-------|-------|-------------|--------------------|
+| 0 | Kernel verification | Extract the refined rotation math, uniform buffer, and energy helpers into the `/core` baseline. Re-run parity tests and document epsilon targets. | `rotationUniforms.ts`, `sixPlaneOrbit.ts`, `rotationEnergy.ts` |
+| 1 | Minimal renderer | Instantiate `HypercubeCore` with one geometry, wire uniform uploads, and expose a bare status HUD. Disable optional layers (water, bloom, lattice) until Stage 4. | `hypercubeCore.ts`, `frameUtils.ts` |
+| 2 | Geometry catalog | Reintroduce tesseract / 24-cell / 600-cell uploads via the GPU-resident pipeline. Validate topology metadata and Euler characteristic assertions. | `geometryCatalog.ts`, `geometryTopology.test.ts` |
+| 3 | Parserator ingestion | Port `parserator.ts`, profile presets, and replay harness into the clean-room branch. Lock down calibration persistence and manifest annotations. | `parserator.ts`, `profiles.ts`, `replayHarness.ts` |
+| 4 | Telemetry + exports | Layer in the dataset manifest builder, latency tracker, telemetry loom, and manifest export button. Confirm worker/fallback parity for frame encoding. | `datasetManifest.ts`, `latencyTracker.ts`, `datasetExport.ts` |
+| 5 | Extruments + audio | Re-enable the extrument hub, MIDI adapter, and audio-reactive shader feeds. Document activation steps and provide defaults that keep external outputs optional. | `extrumentHub.ts`, `midiExtrument.ts`, shader uniform bridges |
+| 6 | Presentation polish | Restore the showcase panel, water plane, bloom, and HUD glyph once performance budgets are measured. Update the QA guide and rebuild log with sign-off steps. | `main.ts` showcase scaffolding, water controls, HUD modules |
+
+## Recommended Immediate Tasks
+
+- **Create staging branches per stage**: mirror the table above so each milestone is reviewable and reversible.
+- **Automate parity CI**: wire Vitest parity suites into CI to fail builds when quaternion/matrix alignment slips.
+- **Document extrument recipes**: expand `docs/system-status.md` with quick-start notes for MIDI routing and external calibration captures.
+- **Prepare operator QA scripts**: script console interactions (profile swap, manifest export, dataset reload) so manual testing follows the staged checklist verbatim.
+
+By keeping the refined rotor pipeline as the immutable foundation and layering capabilities in staged increments, the project can ship a lean MVP without sacrificing the advanced telemetry and extrument integrations that differentiate the experience.

--- a/docs/rotor-pipeline-overview.md
+++ b/docs/rotor-pipeline-overview.md
@@ -1,0 +1,38 @@
+# Refine SO(4) Rotor Pipeline and Extrument Mapping
+
+This document captures the intent and core outcomes of the "Refine SO(4) Rotor Pipeline and Extrument Mapping" work. The branch focused on hardening the six-plane rotation kernel while formalising the bridge between rotation snapshots and external instruments ("extruments").
+
+## Goals
+
+- Guarantee that every subsystem — sequential rotation math, matrix construction, dual-quaternion composition, and GPU uniform uploads — reads the same ordered set of six plane angles.
+- Provide an explicit uniform-buffer contract so render programs bind and update the rotation state deterministically.
+- Normalise external sensor input and expose reusable adapters so rotation snapshots can feed MIDI or other extruments without bespoke wiring for each deployment.
+- Document how the refined pieces fit into the staged rebuild blueprint so future stages can reuse the hardened foundations.
+
+## Rotor Pipeline Improvements
+
+The core rotor pipeline work ensures deterministic parity across the math and rendering paths:
+
+- `rotationMatrixFromAngles`, `applySequentialRotations`, and dual-quaternion helpers share the same `RotationAngles` ordering and produce matching snapshots, keeping CPU math and shader paths in sync.
+- `RotationUniformBuffer` owns the std140-compliant buffer layout and exposes a single `update` call for pushing angles to the GPU, preventing divergent uniforms across programs.
+- `rotationEnergy` offers a shared utility for energy-weighted telemetry and tests to assert immutability when refactoring the kernel.
+- `composeDualQuaternion` and `applyDualQuaternionRotation` reuse scratch buffers and accept caller-provided outputs so streaming flows can avoid per-frame allocations while staying parity-tested against sequential rotations.
+
+## Extrument Mapping
+
+External integration is handled through the extrument hub utilities:
+
+- `ExtrumentHub` wraps adapter registration, connection lifecycle, and guarded broadcasting so multiple outputs can subscribe to rotation updates without interfering with one another.
+- `normalizeSnapshot` converts raw rotation snapshots into bounded magnitudes and plane values suitable for MIDI or other control signals, while `describeSnapshot` generates compact human-readable summaries for logs.
+- The MIDI extrument adapter streams the normalised payload as control-change messages, making it straightforward to route the SO(4) telemetry into external synths or controllers.
+
+## Staged Rebuild Alignment
+
+The rebuild log documents how these refinements feed directly into the staged MVP plan:
+
+- Stage 0/1 reuse the tightened rotation math and uniform buffer as the baseline kernel for the clean-room core.
+- Stage 2 keeps geometry uploads GPU-resident, relying on the same uniform contract to animate polychora without CPU regeneration.
+- Stage 3 extends the extrument mapper into the parserator service, reusing the calibrated sensor gains and deterministic snapshot flow introduced here.
+- Later stages layer telemetry, dataset export, and HAOS orchestration on top of the stable rotation bus, ensuring all downstream systems trust the same snapshot contract.
+
+These notes provide context for anyone resuming the staged rebuild or integrating new extruments against the refined rotor pipeline.

--- a/docs/system-status.md
+++ b/docs/system-status.md
@@ -1,0 +1,93 @@
+# HypercubeCore System Status & QA Guide
+
+This document consolidates the current state of every major HypercubeCore subsystem and
+captures the manual QA flows you can run after producing a testable build.
+
+## Quick Reference
+- **Automated build & verification:** Follow [`docs/testable-build.md`](./testable-build.md).
+- **Primary entry point:** `npm run dev` (served via Vite on port 5173).
+- **Datasets & telemetry:** Persist to `localStorage` and can be exported via the control panel.
+
+## 1. Core Rotation & Rendering
+| Component | Location | Status | Notes |
+| --- | --- | --- | --- |
+| Rotation math primitives | `src/core/sixPlaneOrbit.ts`, `src/core/frameUtils.ts` | ✅ Stable | Shared angle ordering across sequential, matrix, and dual-quaternion helpers. Covered by unit tests for immutability and energy calculations. |
+| Uniform buffer orchestration | `src/core/rotationUniforms.ts`, `src/core/uniformSyncQueue.ts` | ✅ Stable | Std140-aligned `RotationUniformBuffer` manages uploads; `UniformSyncQueue` gates GPU writes to avoid skipped frames. |
+| Renderer shell | `src/core/hypercubeCore.ts` | ✅ Stable | Owns shader compilation, geometry uploads, and per-frame scheduling. Exposes deterministic capture hooks for dataset exports. |
+| Uber shader builder | `src/core/uberShaderBuilder.ts` | ✅ Stable | Generates shader variants with the correct uniform bindings for rotation, audio, and lighting controls. |
+
+### Manual QA
+1. `npm run dev` → open http://localhost:5173.
+2. Rotate geometry with mouse/trackpad; confirm smooth motion and no console errors.
+3. Toggle rotation pause/resume from the control panel to ensure uniforms resume correctly.
+
+## 2. Geometry Catalog
+| Component | Location | Status | Notes |
+| --- | --- | --- | --- |
+| Polychoron topology metadata | `src/geometry/types.ts`, `src/geometry/sixHundredCell.ts`, etc. | ✅ Stable | Every geometry embeds Euler characteristic metadata; unit tests cover the 600-cell vertex/face counts. |
+| Geometry controller | `src/pipeline/geometryController.ts` | ✅ Stable | Manages live swaps with throttled uniform updates and telemetry hooks. |
+
+### Manual QA
+- Cycle through geometries in the console. The status readout should update counts and maintain frame rate.
+
+## 3. Ingestion & Extruments
+| Component | Location | Status | Notes |
+| --- | --- | --- | --- |
+| Parserator service | `src/ingestion/parserator.ts` | ✅ Stable | Profiles, preprocessors, and confidence floors persist to manifests. Tests cover hydration and runtime swaps. |
+| Profile registry | `src/ingestion/profiles.ts` | ✅ Stable | High-gain and smoothing presets available; verified by unit tests. |
+| Replay harness | `src/ingestion/replayHarness.ts` | ✅ Stable | Plays back captured snapshots for deterministic regression runs. |
+| Extrument hub | `src/ingestion/extrumentHub.ts` | ✅ Stable | Normalizes snapshots, manages adapter lifecycles, and guards broadcasts. |
+| MIDI adapter | `src/ingestion/midiExtrument.ts` | ✅ Stable | Streams normalized snapshots as Control Change messages. Vitest covers discovery and payload formatting. |
+
+### Manual QA
+1. Enable the **Extruments** panel, request WebMIDI access, and connect to a virtual synth.
+2. Confirm live rotation updates stream MIDI CC events (verify via synth UI or console logs).
+3. Switch parserator profiles to ensure confidence readings respond immediately.
+
+## 4. Telemetry & Analytics
+| Component | Location | Status | Notes |
+| --- | --- | --- | --- |
+| Telemetry loom | `src/pipeline/telemetryLoom.ts` | ✅ Stable | Snapshot log with serialization, hydration, and capacity clamps; unit-tested. |
+| Confidence trend store | `src/pipeline/confidenceTrend.ts` | ✅ Stable | Tracks rolling high-confidence ratios with parserator calibration annotations and persistence to localStorage. |
+| Latency tracker | `src/pipeline/latencyTracker.ts` | ✅ Stable | Records uniform, capture, and encode timing envelopes for each frame. |
+| Focus director | `src/pipeline/focusDirector.ts` | ✅ Stable | Adjusts camera focus based on rotation energy and telemetry thresholds. |
+| HAOS bridge | `src/pipeline/haosBridge.ts` | ✅ Stable | Publishes telemetry snapshots to external orchestration clients. |
+
+### Manual QA
+- Observe the telemetry timeline in the console. Trigger rotations and dataset exports; confirm logs, latencies, and confidence sparkline update without exceeding capacity limits.
+
+## 5. Dataset Export Pipeline
+| Component | Location | Status | Notes |
+| --- | --- | --- | --- |
+| Manifest builder | `src/pipeline/datasetManifest.ts` | ✅ Stable | Deterministic file naming, p95 latency aggregation, hydration from prior manifests, and persists confidence-trend sparkline samples. |
+| Dataset exporter | `src/pipeline/datasetExport.ts` | ✅ Stable | Orchestrates capture, encoding (worker or JSON fallback), and manifest persistence. |
+| Frame encoding | `src/pipeline/frameEncoding.ts`, `src/pipeline/datasetWorker.ts` | ✅ Stable | Worker-backed pipeline with fallback path; tests cover both execution modes. |
+| PSP stream | `src/pipeline/pspStream.ts` | ✅ Stable | Streams captured frames for progressive preview during exports. |
+
+### Manual QA
+1. Accumulate frames (allow the capture queue to run until non-zero frame count is shown).
+2. Click **Download Manifest**; verify file name uses timestamped deterministic format.
+3. Inspect manifest JSON for telemetry envelopes, confidence histogram, extrument state, and the `confidenceTrend` sparkline payload (each `sample` should include the parserator profile, confidence floor, and preprocessors active for that datapoint).
+
+## 6. Control Panel & UI Layer
+| Component | Location | Status | Notes |
+| --- | --- | --- | --- |
+| Control panel wiring | `src/main.ts` | ✅ Stable | Hydrates/persists confidence trends, telemetry logs, manifest snapshots, and extrument status.
+| UI assets | `index.html` | ✅ Stable | Hosts the console layout, dataset controls, extrument panel, and telemetry widgets.
+
+### Manual QA
+- Use the console toggles for parserator, telemetry overlays, and dataset exporters. Ensure each panel persists state across refreshes (localStorage-backed).
+
+## 7. Documentation & Operational Notes
+- [`docs/rebuild-log.md`](./rebuild-log.md): Session-by-session history tying new capabilities to the staged rebuild blueprint.
+- [`docs/rotor-pipeline-overview.md`](./rotor-pipeline-overview.md): High-level rationale for the refined rotation and extrument systems.
+- [`docs/testable-build.md`](./testable-build.md): Command checklist for automated verification.
+
+## Manual QA Checklist (Post-Automation)
+1. Produce a clean workspace and install dependencies.
+2. Run all automated checks per `docs/testable-build.md`.
+3. Start the dev server and perform the manual QA steps outlined in Sections 1–6.
+4. Export a dataset manifest and verify telemetry payloads.
+5. (Optional) Connect a WebMIDI target to validate extrument streaming in a live environment.
+
+Completing this checklist confirms the refined SO(4) rotor pipeline, dataset exporter, telemetry instrumentation, and extrument mapping are functioning end-to-end.

--- a/docs/testable-build.md
+++ b/docs/testable-build.md
@@ -1,0 +1,27 @@
+# Testable Build Checklist
+
+To generate a repeatable HypercubeCore build with full test coverage:
+
+1. **Install dependencies**
+   ```bash
+   npm install
+   ```
+2. **Run the automated test suite**
+   Executes Vitest unit tests for the rotation bus, telemetry pipeline, dataset export, and extrument adapters.
+   ```bash
+   npm test -- --run
+   ```
+3. **Static type analysis**
+   Validates the TypeScript surface (including WebMIDI adapters and worker harnesses) for nullable DOM handles and interface mismatches.
+   ```bash
+   npm run typecheck
+   ```
+4. **Production bundle**
+   Emits the optimized Vite build (including the dataset worker) into `dist/`.
+   ```bash
+   npm run build
+   ```
+
+Running the commands in this order ensures the rotor pipeline, dataset exporter, and extrument mapping are ready for manual QA or downstream automation.
+
+Once the checklist passes, continue with the subsystem walkthrough and hands-on validation steps in [`docs/system-status.md`](./system-status.md) to finish personal testing.

--- a/hypercube-lattice-webgl-visualizer.md
+++ b/hypercube-lattice-webgl-visualizer.md
@@ -1,7 +1,9 @@
 
 ### Hypercube Lattice WebGL Visualizer
 
-*   **File Path:** `/mnt/c/Users/millz/Desktop/hypercubeapp0.2/app.js`
+> **Current Implementation:** The production version of this visualizer now lives inside the HypercubeCore TypeScript modules: `src/core/hypercubeCore.ts`, `src/core/uberShaderBuilder.ts`, and `src/core/rotationUniforms.ts`, with fragment shader assembly handled by `UberShaderBuilder`. The historical notes below describe the earlier prototype hosted in `app.js` and remain for archival context.
+
+*   **Historical File Path:** `/mnt/c/Users/millz/Desktop/hypercubeapp0.2/app.js`
 *   **Dependencies:** WebGL
 *   **Visual Description:** This is a highly customizable WebGL visualizer that renders a 4D hypercube lattice. It supports various visual parameters that can be dynamically controlled, creating effects like morphing, RGB glitching, rotation, and density changes. The visualizer's color scheme and overall "feel" can be shifted to match different "universes" (Timekeeper, Soundfields, Spiritual, World Builder, Design Patterns, Fusion Lab).
 *   **Key Features & Effects:**

--- a/hypercube_core_webgl_system.md
+++ b/hypercube_core_webgl_system.md
@@ -1,365 +1,53 @@
 # HypercubeCore WebGL System Documentation
-*High-Performance 4D Visualization Framework with Dynamic Shader Management*
+*Real-time SO(4) Rendering with Deterministic Uniform Management*
+
+This document reflects the current TypeScript implementation under `src/core/` and `src/pipeline/`. Earlier drafts referenced ad-hoc JavaScript prototypes; all sections below now map to concrete modules in the repository.
 
 ## System Overview
 
-The HypercubeCore system represents a sophisticated WebGL-based framework for real-time 4D mathematical visualization. This modular architecture provides dynamic shader compilation, comprehensive state management, and high-performance rendering of complex hyperdimensional geometries.
+HypercubeCore is a WebGL2 renderer that accepts six-plane SO(4) rotation snapshots, keeps geometry resident on the GPU, and exposes capture hooks for dataset export and telemetry pipelines. It cooperates with the parserator ingestion stack and pipeline services described in the staged rebuild blueprint.
 
 ## Core Architecture
 
-### Primary Components
+### HypercubeCore (`src/core/hypercubeCore.ts`)
+- Manages WebGL2 context acquisition, shader compilation via `UberShaderBuilder`, VAO state, and animation loop scheduling.
+- Owns a single `RotationUniformBuffer` instance and guarantees std140-compliant uploads through `setRotations`.
+- Provides `captureFrame` and `setUniformUploadListener` to synchronise dataset exports with the exact snapshot presented to the GPU.
+- Exposes `setGeometry` to bind vertex buffers sourced from `src/geometry/` definitions (tesseract, 24-cell, 600-cell, etc.).
 
-#### 1. HypercubeCore.js - Main Rendering Engine
-**Location**: `/mnt/c/Users/millz/Desktop/629claude/core/HypercubeCore.js`
+### Rotation Uniform Management (`src/core/rotationUniforms.ts`)
+- Defines `RotationAngles`, `RotationSnapshot`, and `rotationEnergy` utilities reused across ingestion and telemetry.
+- Allocates a vec4×2 uniform buffer (`FLOATS_PER_BLOCK = 8`) to align with std140 rules and avoid driver-specific padding bugs.
+- Provides deterministic update semantics that tests cover in `rotationUniforms.test.ts`.
 
-**Key Features**:
-- Comprehensive WebGL state management with context loss recovery
-- Real-time shader compilation and hot-swapping
-- Optimized uniform management with dirty state tracking
-- Full-screen quad rendering for raymarching techniques
-- Animation loop with precise timing controls
-- Error handling and graceful degradation
+### Six-Plane Orbit & Shader Assembly
+- `sixPlaneOrbit.ts` – builds sequential rotation matrices, applies dual-quaternion parity tests, and exposes the canonical plane key ordering used across the codebase.
+- `uberShaderBuilder.ts` – assembles vertex/fragment shader sources with projection, lighting, and debug instrumentation injected at build time. Tests in `uberShaderBuilder.test.ts` ensure generated shaders include required uniform blocks and macros.
 
-**State Management**:
-```javascript
-DEFAULT_STATE = {
-  // Timing & Performance
-  startTime: 0, lastUpdateTime: 0, deltaTime: 0, time: 0.0,
-  resolution: [0, 0], isRendering: false, animationFrameId: null,
-  
-  // Core Visualization Parameters  
-  geometryType: 'hypercube', projectionMethod: 'perspective', dimensions: 4.0,
-  morphFactor: 0.5, rotationSpeed: 0.2, universeModifier: 1.0,
-  patternIntensity: 1.0, gridDensity: 8.0,
-  
-  // Precision Thickness Controls
-  lineThickness: 0.03, shellWidth: 0.025, tetraThickness: 0.035,
-  
-  // Visual Effects
-  glitchIntensity: 0.0, colorShift: 0.0,
-  
-  // Audio Integration
-  audioLevels: { bass: 0, mid: 0, high: 0 },
-  
-  // Color System
-  colorScheme: { 
-    primary: [1.0, 0.2, 0.8], 
-    secondary: [0.2, 1.0, 1.0], 
-    background: [0.05, 0.0, 0.2] 
-  },
-  
-  // System Control
-  needsShaderUpdate: false, _dirtyUniforms: new Set(),
-  shaderProgramName: 'maleficarumViz',
-  callbacks: { onRender: null, onError: null }
-}
-```
+### Geometry Catalogue (`src/geometry/`)
+- `types.ts` defines topology metadata, Euler characteristic checks, and typed attribute layouts.
+- `tesseract.ts`, `twentyFourCell.ts`, `sixHundredCell.ts` provide static buffers for regular polychora with deterministic vertex ordering.
+- `geometryTopology.test.ts` guards vertex/edge/facet counts and Euler characteristic invariants.
 
-#### 2. ShaderManager.js - Dynamic Shader Compilation System
-**Location**: `/mnt/c/Users/millz/Desktop/629claude/core/ShaderManager.js`
+## Pipeline Integration Points
 
-**Advanced Features**:
-- Dynamic fragment shader assembly with geometry/projection injection
-- Shader compilation error logging with line-by-line debugging
-- Program linking and uniform/attribute location caching
-- Hot-reload shader replacement without context loss
-- Base vertex/fragment shader templates
+### Uniform Sync Queue (`src/core/uniformSyncQueue.ts`)
+- Records every uniform upload with timestamps, pending queue depth, and skip counters used by latency trackers.
+- Tests validate that enqueued snapshots resolve in order and remain immutable.
 
-**Shader Template System**:
-```glsl
-// Base Fragment Shader with Injection Points
-precision highp float;
-// Standard uniforms for 4D mathematics
-uniform vec2 u_resolution; uniform float u_time;
-uniform float u_dimension; uniform float u_morphFactor; 
-uniform float u_rotationSpeed; uniform float u_universeModifier;
-uniform float u_patternIntensity; uniform float u_gridDensity;
-// Precision thickness controls for different geometries
-uniform float u_lineThickness; uniform float u_shellWidth; 
-uniform float u_tetraThickness;
-// Audio reactivity
-uniform float u_audioBass; uniform float u_audioMid; uniform float u_audioHigh;
-// Visual effects
-uniform float u_glitchIntensity; uniform float u_colorShift;
-// Color system
-uniform vec3 u_primaryColor; uniform vec3 u_secondaryColor; 
-uniform vec3 u_backgroundColor;
+### Dataset Export & Telemetry (`src/pipeline/`)
+- `datasetExport.ts` coordinates capture triggers, PSP export, and worker delegation via `datasetWorker.ts`.
+- `latencyTracker.ts`, `telemetryLoom.ts`, and `confidenceTrend.ts` consume metrics from the uniform sync queue to surface operator dashboards in the control panel.
+- `datasetManifest.ts` persists per-frame latency envelopes, parserator calibration context, and deterministic asset naming for archival.
 
-// 4D Rotation Matrix Functions (6 rotation planes)
-mat4 rotXW(float a), rotYW(float a), rotZW(float a),
-mat4 rotXY(float a), rotYZ(float a), rotXZ(float a);
+## Control Panel (`index.html`, `src/main.ts`)
+- Organises controls into rotation, geometry, parserator, extrument, dataset telemetry, and manifest sections.
+- Hydrates persistent state (confidence trends, telemetry loom, manifests) on load and wires UI actions to the corresponding services.
+- Displays uniform upload counts, capture/encode latency, extrument connection state, and manifest statistics to keep operators aligned with runtime behaviour.
 
-// Color space conversion utilities
-vec3 rgb2hsv(vec3 c), vec3 hsv2rgb(vec3 c);
+## Development & Testing
+- **Build/Test Commands:** `npm install`, `npm test -- --run`, `npm run typecheck`, `npm run build` (see `docs/testable-build.md`).
+- **Unit Coverage:** Vitest suites cover rotation math, uniform buffer semantics, parserator calibration flows, extrument hub behaviour, dataset export, manifest persistence, telemetry analytics, and worker fallbacks.
+- **Manual QA:** Control-panel telemetry and extrument summaries provide real-time validation when testing new parserator profiles or external adapters.
 
-//__PROJECTION_CODE_INJECTION_POINT__
-//__GEOMETRY_CODE_INJECTION_POINT__
-
-void main() {
-  // Advanced raymarching with 4D projection
-  // Dynamic camera system with audio-reactive movement
-  // Multi-layer color mixing with HSV manipulation
-  // RGB glitch effects with channel separation
-}
-```
-
-#### 3. GeometryManager.js - Mathematical Geometry Definitions
-**Location**: `/mnt/c/Users/millz/Desktop/629claude/core/GeometryManager.js`
-
-**Implemented Geometries**:
-
-##### HypercubeGeometry - 4D Lattice Structures
-```glsl
-float calculateLattice(vec3 p) {
-  // Dynamic parameters based on audio input
-  float dynamicGridDensity = max(0.1, u_gridDensity * (1.0 + u_audioBass * 0.7));
-  float dynamicLineThickness = max(0.002, u_lineThickness * (1.0 - u_audioMid * 0.6));
-  
-  // 3D lattice base calculation
-  vec3 p_grid3D = fract(p * dynamicGridDensity * 0.5 + u_time * 0.01);
-  vec3 dist3D = abs(p_grid3D - 0.5);
-  float box3D = max(dist3D.x, max(dist3D.y, dist3D.z));
-  float lattice3D = smoothstep(0.5, 0.5 - dynamicLineThickness, box3D);
-  
-  // 4D extension with complex rotations
-  float dim_factor = smoothstep(3.0, 4.5, u_dimension);
-  if (dim_factor > 0.01) {
-    // Generate W coordinate using sine/cosine combinations
-    float w_coord = sin(p.x*1.4 - p.y*0.7 + p.z*1.5 + u_time * 0.25)
-                  * cos(length(p) * 1.1 - u_time * 0.35 + u_audioMid * 2.5)
-                  * dim_factor * (0.4 + u_morphFactor * 0.6 + u_audioHigh * 0.6);
-    
-    vec4 p4d = vec4(p, w_coord);
-    
-    // Multiple 4D rotation planes with different speeds
-    float baseSpeed = u_rotationSpeed * 1.0;
-    p4d = rotXW(u_time * 0.33 * baseSpeed + u_audioHigh * 0.25) * 
-          rotYZ(u_time * 0.28 * baseSpeed - u_audioMid * 0.28) * 
-          rotZW(u_time * 0.25 * baseSpeed + u_audioBass * 0.35) * 
-          rotYW(u_time * -0.22 * baseSpeed + u_morphFactor * 0.3) * p4d;
-    
-    // Project 4D to 3D and calculate lattice
-    vec3 projectedP = project4Dto3D(p4d);
-    // ... [lattice calculation continues]
-  }
-  
-  return pow(finalLattice, 1.0 / max(0.1, u_universeModifier));
-}
-```
-
-##### HypersphereGeometry - Spherical Shell Structures
-- Dynamic shell width control with `u_shellWidth` parameter
-- Nested 3D/4D sphere calculations with radius-based density
-- Audio-reactive phase shifting and shell thickness
-
-##### HypertetrahedronGeometry - Tetrahedral Face Projections
-- Planar distance calculations using normalized corner vectors
-- `u_tetraThickness` parameter for edge definition control
-- Complex 4D tetrahedral cell projections
-
-#### 4. ProjectionManager.js - 4D to 3D Projection Systems
-**Location**: `/mnt/c/Users/millz/Desktop/629claude/core/ProjectionManager.js`
-
-**Projection Types**:
-
-##### PerspectiveProjection
-```glsl
-vec3 project4Dto3D(vec4 p) {
-  float baseDistance = 2.5;
-  float dynamicDistance = max(0.2, baseDistance * (1.0 + u_morphFactor * 0.4 - u_audioMid * 0.35));
-  float denominator = dynamicDistance + p.w;
-  float w_factor = dynamicDistance / max(0.1, denominator);
-  return p.xyz * w_factor;
-}
-```
-
-##### StereographicProjection
-- Configurable projection pole for different viewing angles
-- Automatic epsilon handling for singularity avoidance
-- Dynamic pole adjustment based on audio input
-
-##### OrthographicProjection
-- Blends between orthographic and perspective based on morphFactor
-- Maintains parallel projection properties for mathematical accuracy
-
-## Advanced Geometric Systems
-
-### Crystal Lattice Geometry System
-**Location**: `/mnt/c/Users/millz/Desktop/629claude/CrystalGeometry.js`
-
-**Features**:
-- Parametric hypercubic lattice generation
-- 4D point clouds with edge connectivity
-- Configurable unit cell spacing and lattice dimensions
-- CPU-based 4D rotations with 6-axis rotation support
-- WebGL buffer management with index optimization
-
-**Key Parameters**:
-```javascript
-parameters: {
-  latticeSize: [3, 3, 3, 2], // [nx, ny, nz, nw] grid dimensions
-  unitCellSpacing: 0.5,      // Distance between lattice points
-  pointRepresentation: 'point' // 'point', 'smallCube', 'sphere'
-}
-```
-
-### Hypersphere Geometry System  
-**Location**: `/mnt/c/Users/millz/Desktop/629claude/HypersphereGeometry.js`
-
-**Advanced Features**:
-- True 3-sphere (S³) surface generation using parametric equations
-- Shell/solid mode with configurable inner/outer surfaces
-- Multi-division surface tessellation (U/V/W angular divisions)
-- 4D normal vector calculations for lighting
-- Complex surface indexing for triangle mesh generation
-
-**Parametric 3-Sphere Equations**:
-```javascript
-// Full 3-sphere coverage with chi ∈ [0, π]
-x = r * cos(chi) * sin(theta) * cos(phi)
-y = r * cos(chi) * sin(theta) * sin(phi)  
-z = r * cos(chi) * cos(theta)
-w = r * sin(chi)
-```
-
-### INSANE Hyperdimensional Matrix
-**Location**: `/mnt/c/Users/millz/Desktop/629claude/InsaneGeometry.js`
-
-**Mind-Bending Features**:
-- 8D to 4D dimensional projection with reality distortion
-- Fractal hypercube tessellations with recursive depth control
-- Quantum tunneling visual effects with probability distribution
-- Strange attractor field generation (Lorenz-like systems)
-- Hyperspace flow fields with multi-layer turbulence
-- Reality-bending post-processing with time-warp effects
-
-**Extreme Parameters**:
-```javascript
-parameters: {
-  chaosLevel: { min: 0.0, max: 10.0, default: 5.0 },
-  dimensionBreak: { min: 3.0, max: 8.0, default: 4.2 },
-  timeWarp: { min: 0.1, max: 50.0, default: 1.0 },
-  fractalDepth: { min: 1, max: 20, default: 8 },
-  quantumTunnel: { min: 0.0, max: 5.0, default: 2.0 },
-  realityBend: { min: 0.0, max: 100.0, default: 25.0 },
-  chaosAttractor: { min: 0.0, max: 10.0, default: 3.14 },
-  hyperspaceFlow: { min: 0.0, max: 20.0, default: 7.5 }
-}
-```
-
-## Performance Optimizations
-
-### Uniform Management System
-- Dirty state tracking prevents unnecessary GPU uploads
-- Batch uniform updates per frame
-- Cached uniform/attribute location lookup
-- Automatic retry mechanism for failed uniform sets
-
-### WebGL Context Management
-- Automatic viewport resizing with canvas dimension tracking
-- Context loss detection and recovery
-- Proper buffer cleanup and memory management
-- Extension detection for enhanced capabilities
-
-### Rendering Pipeline
-- Full-screen quad optimization for raymarching
-- Triangle strip rendering for minimal vertex processing
-- Alpha blending configuration for transparency effects
-- Depth testing disabled for overlay effects
-
-## Integration Guidelines
-
-### Basic Implementation
-```javascript
-// Initialize WebGL context and managers
-const canvas = document.getElementById('hypercube-canvas');
-const gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl');
-
-const geometryManager = new GeometryManager();
-const projectionManager = new ProjectionManager();
-const shaderManager = new ShaderManager(gl, geometryManager, projectionManager);
-
-// Create HypercubeCore instance
-const hypercubeCore = new HypercubeCore(canvas, shaderManager, {
-  geometryType: 'hypercube',
-  projectionMethod: 'perspective',
-  colorScheme: {
-    primary: [1.0, 0.2, 0.8],
-    secondary: [0.2, 1.0, 1.0],
-    background: [0.05, 0.0, 0.2]
-  }
-});
-
-// Start rendering
-hypercubeCore.start();
-```
-
-### Parameter Updates
-```javascript
-// Real-time parameter modification
-hypercubeCore.updateParameters({
-  morphFactor: 0.8,
-  rotationSpeed: 1.5,
-  audioLevels: { bass: 0.3, mid: 0.7, high: 0.2 },
-  colorShift: 0.5
-});
-
-// Geometry switching (triggers shader recompilation)
-hypercubeCore.updateParameters({
-  geometryType: 'hypersphere',
-  projectionMethod: 'stereographic'
-});
-```
-
-### Event Handling
-```javascript
-// Setup callbacks for monitoring
-const hypercubeCore = new HypercubeCore(canvas, shaderManager, {
-  callbacks: {
-    onRender: (state) => {
-      // Frame-by-frame state monitoring
-      console.log(`FPS: ${1000 / state.deltaTime}, Time: ${state.time}`);
-    },
-    onError: (error) => {
-      // Error handling and recovery
-      console.error('HypercubeCore Error:', error);
-    }
-  }
-});
-```
-
-## Technical Specifications
-
-### Browser Compatibility
-- **WebGL 1.0**: Full support for all features
-- **WebGL 2.0**: Enhanced with additional extensions
-- **Fallback**: Graceful degradation for older browsers
-
-### Performance Characteristics
-- **Target FPS**: 60 FPS at 1920x1080
-- **GPU Memory**: ~10-50MB depending on geometry complexity
-- **CPU Usage**: <5% on modern hardware
-- **Mobile Support**: Optimized for mobile GPUs with reduced precision
-
-### Shader Complexity
-- **Vertex Shader**: Simple full-screen quad transformation
-- **Fragment Shader**: Complex raymarching with up to 80 iterations
-- **Uniform Count**: 20+ uniforms for comprehensive parameter control
-- **Precision**: `highp float` for mathematical accuracy
-
-## Future Enhancements
-
-### Planned Features
-1. **WebGL 2.0 Migration**: Transform feedback for GPU-based computations
-2. **Compute Shaders**: WebGPU integration for advanced algorithms
-3. **Instance Rendering**: Multiple geometry instances with varied parameters
-4. **Temporal Accumulation**: Motion blur and temporal anti-aliasing
-5. **Ray Tracing Integration**: Hardware-accelerated ray tracing where available
-
-### Extensibility Points
-- **Custom Geometries**: Implement `BaseGeometry` for new mathematical structures
-- **Custom Projections**: Extend `BaseProjection` for novel viewing transformations
-- **Audio Integration**: Enhanced Web Audio API integration with FFT analysis
-- **VR/AR Support**: WebXR integration for immersive 4D exploration
-
-This system represents the cutting edge of real-time 4D mathematical visualization in web browsers, combining sophisticated mathematics with high-performance WebGL rendering techniques.
+Maintaining the documentation in this format ensures future contributors can map architectural concepts directly to the TypeScript modules that implement them.

--- a/index.html
+++ b/index.html
@@ -5,7 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>HypercubeCore – SO(4) MVP</title>
     <style>
-      html, body {
+      html,
+      body {
         margin: 0;
         padding: 0;
         height: 100%;
@@ -26,6 +27,7 @@
         display: flex;
         flex-direction: column;
         gap: 24px;
+        overflow-y: auto;
       }
       #control-panel h1 {
         font-size: 1.25rem;
@@ -43,17 +45,192 @@
         letter-spacing: 0.08em;
         color: #9edcff;
       }
+      .telemetry {
+        border-top: 1px solid rgba(86, 180, 252, 0.2);
+        padding-top: 12px;
+        margin-top: 12px;
+        gap: 8px;
+      }
+      .telemetry-row {
+        display: flex;
+        justify-content: space-between;
+        font-size: 0.75rem;
+        color: rgba(211, 246, 255, 0.85);
+      }
+      .telemetry-row span:first-child {
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        color: rgba(144, 202, 249, 0.85);
+      }
       .control-group input[type="range"] {
         width: 100%;
+      }
+      button {
+        padding: 10px 12px;
+        border: 1px solid rgba(127, 210, 255, 0.4);
+        border-radius: 6px;
+        background: linear-gradient(135deg, rgba(23, 74, 120, 0.8), rgba(15, 36, 62, 0.8));
+        color: #e7faff;
+        font-size: 0.8rem;
+        font-weight: 600;
+        letter-spacing: 0.04em;
+        cursor: pointer;
+        transition: background 0.2s ease, transform 0.2s ease;
+      }
+      button:hover:not(:disabled) {
+        background: linear-gradient(135deg, rgba(33, 104, 168, 0.9), rgba(20, 50, 86, 0.9));
+        transform: translateY(-1px);
+      }
+      button:disabled {
+        opacity: 0.45;
+        cursor: default;
+      }
+      .telemetry-chart {
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+      }
+      .telemetry-chart label {
+        font-size: 0.7rem;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        color: rgba(144, 202, 249, 0.65);
+      }
+      .telemetry-chart canvas {
+        width: 100%;
+        height: 64px;
+        border-radius: 6px;
+        border: 1px solid rgba(86, 180, 252, 0.16);
+        background: rgba(12, 18, 32, 0.35);
+        display: block;
       }
       canvas {
         width: 100%;
         height: 100%;
         display: block;
       }
+      #extrument-payload {
+        font-family: "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+        display: inline-block;
+        max-width: 180px;
+        text-align: right;
+        line-height: 1.3;
+        word-break: break-word;
+      }
+      #parserator-preprocessor-controls {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+      }
+      .parserator-toggle {
+        display: flex;
+        gap: 10px;
+        align-items: flex-start;
+        background: rgba(18, 32, 52, 0.35);
+        border: 1px solid rgba(86, 180, 252, 0.16);
+        border-radius: 6px;
+        padding: 8px;
+      }
+      .parserator-toggle input[type="checkbox"] {
+        margin-top: 4px;
+      }
+      .parserator-toggle span {
+        font-size: 0.78rem;
+        color: rgba(211, 246, 255, 0.9);
+        font-weight: 600;
+        display: block;
+      }
+      .parserator-toggle small {
+        display: block;
+        margin-top: 2px;
+        font-size: 0.68rem;
+        color: rgba(158, 220, 255, 0.7);
+      }
+      #telemetry-events {
+        list-style: none;
+        margin: 6px 0 0;
+        padding: 0;
+        max-height: 200px;
+        overflow-y: auto;
+        background: rgba(18, 32, 52, 0.3);
+        border: 1px solid rgba(86, 180, 252, 0.16);
+        border-radius: 8px;
+      }
+      #telemetry-events li {
+        display: flex;
+        justify-content: space-between;
+        align-items: flex-start;
+        gap: 12px;
+        padding: 8px 10px;
+        border-bottom: 1px solid rgba(211, 246, 255, 0.08);
+      }
+      #telemetry-events li:last-child {
+        border-bottom: none;
+      }
+      .telemetry-text {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+      }
+      .telemetry-message {
+        font-size: 0.8rem;
+        font-weight: 600;
+        color: #d3f6ff;
+      }
+      .telemetry-metadata {
+        font-size: 0.7rem;
+        color: rgba(211, 246, 255, 0.7);
+      }
+      .telemetry-timestamp {
+        font-size: 0.68rem;
+        color: rgba(211, 246, 255, 0.6);
+        white-space: nowrap;
+        font-variant-numeric: tabular-nums;
+      }
+      #telemetry-events li[data-category="parserator"] .telemetry-message {
+        color: #9ad7ff;
+      }
+      #telemetry-events li[data-category="extrument"] .telemetry-message {
+        color: #f9d882;
+      }
+      #telemetry-events li[data-category="system"] .telemetry-message {
+        color: #b5ffe1;
+      }
+      .telemetry-empty {
+        padding: 10px;
+        text-align: center;
+        color: rgba(211, 246, 255, 0.6);
+        font-size: 0.75rem;
+      }
+      #parserator-confidence-value {
+        font-variant-numeric: tabular-nums;
+      }
       #status {
         font-size: 0.75rem;
         color: rgba(211, 246, 255, 0.7);
+      }
+
+      @media (max-width: 900px) {
+        html,
+        body {
+          height: auto;
+          min-height: 100%;
+          overflow-y: auto;
+        }
+        #app {
+          grid-template-columns: 1fr;
+          grid-template-rows: auto minmax(0, 1fr);
+          height: auto;
+          min-height: 100vh;
+        }
+        #control-panel {
+          border-right: none;
+          border-bottom: 1px solid rgba(86, 180, 252, 0.25);
+          max-height: 70vh;
+        }
+        canvas {
+          min-height: 320px;
+        }
       }
     </style>
   </head>
@@ -79,6 +256,102 @@
         <section class="control-group">
           <label for="lineWidth">Line Width</label>
           <input id="lineWidth" type="range" min="1" max="6" step="0.5" value="2" />
+        </section>
+        <section id="telemetry" class="control-group telemetry">
+          <div class="telemetry-row">
+            <span>Uniform uploads</span>
+            <span id="uniform-uploads">0</span>
+          </div>
+          <div class="telemetry-row">
+            <span>Uniform skips</span>
+            <span id="uniform-skips">0</span>
+          </div>
+          <div class="telemetry-row">
+            <span>Uniform latency</span>
+            <span id="uniform-latency">0 ms</span>
+          </div>
+          <div class="telemetry-row">
+            <span>Capture latency</span>
+            <span id="capture-latency">0 ms</span>
+          </div>
+          <div class="telemetry-row">
+            <span>Pending frames</span>
+            <span id="dataset-pending">0</span>
+          </div>
+          <div class="telemetry-row">
+            <span>Encoded frames</span>
+            <span id="dataset-total">0</span>
+          </div>
+          <div class="telemetry-row">
+            <span>Encode latency</span>
+            <span id="encode-latency">0 ms</span>
+          </div>
+          <div class="telemetry-row">
+            <span>Last format</span>
+            <span id="dataset-format">–</span>
+          </div>
+          <div class="telemetry-row">
+            <span>Manifest frames</span>
+            <span id="manifest-frames">0</span>
+          </div>
+          <div class="telemetry-row">
+            <span>Manifest p95</span>
+            <span id="manifest-p95">–</span>
+          </div>
+          <div class="telemetry-row">
+            <span>Confidence ≥0.9</span>
+            <span id="manifest-confidence">–</span>
+          </div>
+          <div class="telemetry-row">
+            <span>Manifest updated</span>
+            <span id="manifest-updated">–</span>
+          </div>
+          <div class="telemetry-chart">
+            <label for="manifest-confidence-trend">Confidence trend</label>
+            <canvas id="manifest-confidence-trend" width="280" height="64" aria-hidden="true"></canvas>
+          </div>
+          <button id="manifest-download">Download manifest</button>
+        </section>
+        <section id="parserator" class="control-group telemetry">
+          <div class="telemetry-row">
+            <span>Active profile</span>
+            <span id="parserator-profile-name">Default IMU</span>
+          </div>
+          <div class="telemetry-row">
+            <span>Confidence floor</span>
+            <span id="parserator-confidence-value">0.60</span>
+          </div>
+          <div class="telemetry-row">
+            <span>Preprocessors</span>
+            <span id="parserator-preprocessors">–</span>
+          </div>
+          <label for="parserator-profile-select">Mapping profile</label>
+          <select id="parserator-profile-select"></select>
+          <label for="parserator-confidence-input">Confidence floor</label>
+          <input id="parserator-confidence-input" type="range" min="0" max="1" step="0.01" value="0.60" />
+          <div id="parserator-preprocessor-controls"></div>
+        </section>
+        <section id="telemetry-history" class="control-group telemetry">
+          <div class="telemetry-row">
+            <span>Parserator timeline</span>
+            <span id="telemetry-count">0 events</span>
+          </div>
+          <ul id="telemetry-events" role="log" aria-live="polite" aria-relevant="additions text"></ul>
+        </section>
+        <section id="extrument" class="control-group telemetry">
+          <div class="telemetry-row">
+            <span>Extrument</span>
+            <span id="extrument-status">Idle</span>
+          </div>
+          <div class="telemetry-row">
+            <span>Outputs</span>
+            <span id="extrument-output">–</span>
+          </div>
+          <div class="telemetry-row">
+            <span>Last frame</span>
+            <span id="extrument-payload">–</span>
+          </div>
+          <button id="extrument-connect">Connect MIDI Extrument</button>
         </section>
       </aside>
       <canvas id="gl-canvas"></canvas>

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,13 @@
         "typescript": "^5.4.5",
         "vite": "^5.2.0",
         "vitest": "^1.3.1"
+      },
+      "scripts": {
+        "dev": "vite",
+        "build": "vite build",
+        "preview": "vite preview",
+        "test": "vitest",
+        "typecheck": "tsc --noEmit"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "vitest"
+    "test": "vitest",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "gl-matrix": "^3.4.3"

--- a/src/core/frameUtils.test.ts
+++ b/src/core/frameUtils.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { flipPixelsVertically } from './frameUtils';
+
+function createCheckerboard(width: number, height: number): Uint8Array {
+  const data = new Uint8Array(width * height * 4);
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      const index = (y * width + x) * 4;
+      const on = (x + y) % 2 === 0;
+      data[index + 0] = on ? 255 : 0;
+      data[index + 1] = on ? 128 : 0;
+      data[index + 2] = on ? 64 : 0;
+      data[index + 3] = 255;
+    }
+  }
+  return data;
+}
+
+describe('flipPixelsVertically', () => {
+  it('returns a vertically flipped copy of the pixel buffer', () => {
+    const width = 2;
+    const height = 3;
+    const source = createCheckerboard(width, height);
+    const flipped = flipPixelsVertically(width, height, source);
+
+    // Top row in source should become bottom row in flipped
+    const sourceTop = Array.from(source.slice(0, width * 4));
+    const flippedBottom = Array.from(flipped.slice((height - 1) * width * 4));
+    expect(flippedBottom).toEqual(sourceTop);
+
+    // Bottom row in source should become top row in flipped
+    const sourceBottom = Array.from(source.slice((height - 1) * width * 4));
+    const flippedTop = Array.from(flipped.slice(0, width * 4));
+    expect(flippedTop).toEqual(sourceBottom);
+  });
+});

--- a/src/core/frameUtils.ts
+++ b/src/core/frameUtils.ts
@@ -1,0 +1,14 @@
+export function flipPixelsVertically(
+  width: number,
+  height: number,
+  source: Uint8Array | Uint8ClampedArray
+): Uint8ClampedArray {
+  const bytesPerRow = width * 4;
+  const flipped = new Uint8ClampedArray(source.length);
+  for (let row = 0; row < height; row++) {
+    const srcStart = row * bytesPerRow;
+    const destStart = (height - 1 - row) * bytesPerRow;
+    flipped.set(source.subarray(srcStart, srcStart + bytesPerRow), destStart);
+  }
+  return flipped;
+}

--- a/src/core/rotationUniforms.test.ts
+++ b/src/core/rotationUniforms.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { rotationEnergy, ZERO_ROTATION, type RotationAngles } from './rotationUniforms';
+
+describe('rotationEnergy', () => {
+  it('is zero for the neutral rotation', () => {
+    expect(rotationEnergy(ZERO_ROTATION)).toBe(0);
+  });
+
+  it('sums the absolute magnitude of every plane', () => {
+    const angles: RotationAngles = {
+      xy: Math.PI / 4,
+      xz: -Math.PI / 6,
+      yz: 0,
+      xw: -0.5,
+      yw: 0.75,
+      zw: -1.25
+    };
+
+    const expected =
+      Math.abs(angles.xy) +
+      Math.abs(angles.xz) +
+      Math.abs(angles.yz) +
+      Math.abs(angles.xw) +
+      Math.abs(angles.yw) +
+      Math.abs(angles.zw);
+
+    expect(rotationEnergy(angles)).toBeCloseTo(expected, 1e-10);
+  });
+
+  it('does not mutate the input angles', () => {
+    const angles: RotationAngles = {
+      xy: 0.3,
+      xz: -0.2,
+      yz: 0.1,
+      xw: -0.4,
+      yw: 0.05,
+      zw: -0.6
+    };
+
+    const copy = { ...angles };
+    rotationEnergy(angles);
+    expect(angles).toStrictEqual(copy);
+  });
+});

--- a/src/core/rotationUniforms.ts
+++ b/src/core/rotationUniforms.ts
@@ -65,3 +65,14 @@ export const ZERO_ROTATION: RotationAngles = {
   yw: 0,
   zw: 0
 };
+
+export function rotationEnergy(angles: RotationAngles): number {
+  return (
+    Math.abs(angles.xy) +
+    Math.abs(angles.xz) +
+    Math.abs(angles.yz) +
+    Math.abs(angles.xw) +
+    Math.abs(angles.yw) +
+    Math.abs(angles.zw)
+  );
+}

--- a/src/core/sixPlaneOrbit.test.ts
+++ b/src/core/sixPlaneOrbit.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { createHarmonicOrbit, SIX_PLANE_KEYS } from './sixPlaneOrbit';
+import { createHarmonicOrbit, createRotationLoom, SIX_PLANE_KEYS } from './sixPlaneOrbit';
 
 describe('six plane harmonic orbit', () => {
   it('produces bounded angles for each plane', () => {
@@ -18,5 +18,17 @@ describe('six plane harmonic orbit', () => {
     for (const plane of SIX_PLANE_KEYS) {
       expect(Math.abs(late[plane] - early[plane])).toBeLessThan(0.5);
     }
+  });
+
+  it('records rotation loom samples with bounded length', () => {
+    const orbit = createHarmonicOrbit();
+    const loom = createRotationLoom(orbit, 10);
+    let lastEnergy = 0;
+    for (let i = 0; i < 50; i++) {
+      const samples = loom(i * 0.1);
+      lastEnergy = samples[samples.length - 1]?.energy ?? 0;
+      expect(samples.length).toBeLessThanOrEqual(10);
+    }
+    expect(lastEnergy).toBeGreaterThan(0);
   });
 });

--- a/src/core/sixPlaneOrbit.ts
+++ b/src/core/sixPlaneOrbit.ts
@@ -1,4 +1,4 @@
-import type { RotationAngles } from './rotationUniforms';
+import { rotationEnergy, type RotationAngles } from './rotationUniforms';
 
 const TAU = Math.PI * 2;
 export const SIX_PLANE_KEYS: ReadonlyArray<keyof RotationAngles> = ['xy', 'xz', 'yz', 'xw', 'yw', 'zw'];
@@ -16,6 +16,12 @@ export interface OrbitSpec {
   planes: OrbitPlane[];
   coupling?: number;
   hyperCoupling?: number;
+}
+
+export interface LoomSample {
+  time: number;
+  energy: number;
+  angles: RotationAngles;
 }
 
 const GOLDEN_RATIO = (1 + Math.sqrt(5)) / 2;
@@ -79,5 +85,25 @@ export function createHarmonicOrbit(spec: OrbitSpec = defaultSpec()): (timeSecon
     }
 
     return angles;
+  };
+}
+
+export function createRotationLoom(
+  orbit: (timeSeconds: number) => RotationAngles,
+  length = 240
+): (timeSeconds: number) => LoomSample[] {
+  const samples: LoomSample[] = [];
+  return (timeSeconds: number) => {
+    const angles = orbit(timeSeconds);
+    const energy = rotationEnergy(angles);
+    samples.push({
+      time: timeSeconds,
+      energy,
+      angles: { ...angles }
+    });
+    if (samples.length > length) {
+      samples.shift();
+    }
+    return samples.slice();
   };
 }

--- a/src/core/so4.test.ts
+++ b/src/core/so4.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'vitest';
 import { vec4, mat4 } from 'gl-matrix';
-import { applySequentialRotations, rotationMatrixFromAngles } from './so4';
+import {
+  applySequentialRotations,
+  applyDualQuaternionRotation,
+  rotationMatrixFromAngles,
+  rotationMatrixFromDualQuaternion,
+  composeDualQuaternion
+} from './so4';
 import type { RotationAngles } from './rotationUniforms';
 
 const ANGLES: RotationAngles = {
@@ -25,6 +31,43 @@ describe('SO(4) rotations', () => {
     }
   });
 
+  it('matches dual-quaternion rotation across randomized samples', () => {
+    const vectors = [
+      vec4.fromValues(0.3, -0.4, 0.2, 0.5),
+      vec4.fromValues(-0.8, 0.1, 0.65, -0.12),
+      vec4.fromValues(0.05, -0.9, 0.4, 0.3)
+    ];
+
+    for (let seed = 0; seed < 5; seed++) {
+      const angles: RotationAngles = {
+        xy: Math.sin(seed * 0.37) * 0.8,
+        xz: Math.cos(seed * 0.51) * 0.6,
+        yz: Math.sin(seed * 0.23 + 0.3) * 0.7,
+        xw: Math.cos(seed * 0.41 + 0.2) * 0.5,
+        yw: Math.sin(seed * 0.19 + 0.4) * 0.9,
+        zw: Math.cos(seed * 0.33 + 0.1) * 0.4
+      };
+
+      const dualMatrix = rotationMatrixFromDualQuaternion(angles);
+      const sequentialMatrix = rotationMatrixFromAngles(angles);
+
+      for (let row = 0; row < 4; row++) {
+        for (let col = 0; col < 4; col++) {
+          expect(dualMatrix[col * 4 + row]).toBeCloseTo(sequentialMatrix[col * 4 + row], 1e-5);
+        }
+      }
+
+      for (const vector of vectors) {
+        const sequential = applySequentialRotations(vector, angles);
+        const dualQuaternion = applyDualQuaternionRotation(vector, angles);
+
+        for (let i = 0; i < 4; i++) {
+          expect(dualQuaternion[i]).toBeCloseTo(sequential[i], 1e-5);
+        }
+      }
+    }
+  });
+
   it('produces orthonormal matrix', () => {
     const matrix = rotationMatrixFromAngles(ANGLES);
     const transpose = mat4.transpose(mat4.create(), matrix);
@@ -34,6 +77,37 @@ describe('SO(4) rotations', () => {
         const expected = i === j ? 1 : 0;
         expect(product[i * 4 + j]).toBeCloseTo(expected, 1e-5);
       }
+    }
+  });
+
+  it('writes results into provided buffers', () => {
+    const seedVector = vec4.fromValues(0.12, -0.34, 0.56, -0.78);
+    const angles: RotationAngles = {
+      xy: 0.31,
+      xz: -0.41,
+      yz: 0.23,
+      xw: -0.54,
+      yw: 0.67,
+      zw: -0.12
+    };
+
+    const presetMatrix = mat4.create();
+    const returnedMatrix = rotationMatrixFromAngles(angles, presetMatrix);
+    expect(returnedMatrix).toBe(presetMatrix);
+
+    const leftBuffer = new Float32Array(4);
+    const rightBuffer = new Float32Array(4);
+    const pair = composeDualQuaternion(angles, leftBuffer, rightBuffer);
+    expect(pair.left).toBe(leftBuffer);
+    expect(pair.right).toBe(rightBuffer);
+
+    const target = vec4.create();
+    const rotated = applyDualQuaternionRotation(seedVector, angles, target);
+    expect(rotated).toBe(target);
+
+    const baseline = applySequentialRotations(seedVector, angles);
+    for (let i = 0; i < 4; i++) {
+      expect(rotated[i]).toBeCloseTo(baseline[i], 1e-5);
     }
   });
 });

--- a/src/core/so4.ts
+++ b/src/core/so4.ts
@@ -1,24 +1,33 @@
 import { mat4, vec4 } from 'gl-matrix';
 import type { RotationAngles } from './rotationUniforms';
 
-export function rotationMatrixFromAngles(angles: RotationAngles): mat4 {
+export type QuaternionBuffer = Float32Array | [number, number, number, number];
+
+export interface DualQuaternionPair<L extends QuaternionBuffer = [number, number, number, number], R extends QuaternionBuffer = [number, number, number, number]> {
+  left: L;
+  right: R;
+}
+
+const rotationScratch = mat4.create();
+
+export function rotationMatrixFromAngles(angles: RotationAngles, out?: mat4): mat4 {
   const { xy, xz, yz, xw, yw, zw } = angles;
-  const m = mat4.create();
-  mat4.identity(m);
+  const matrix = out ?? mat4.create();
+  mat4.identity(matrix);
 
-  applyRotationToMatrix(m, xy, rotateXY);
-  applyRotationToMatrix(m, xz, rotateXZ);
-  applyRotationToMatrix(m, yz, rotateYZ);
-  applyRotationToMatrix(m, xw, rotateXW);
-  applyRotationToMatrix(m, yw, rotateYW);
-  applyRotationToMatrix(m, zw, rotateZW);
+  applyRotationToMatrix(matrix, xy, rotateXY);
+  applyRotationToMatrix(matrix, xz, rotateXZ);
+  applyRotationToMatrix(matrix, yz, rotateYZ);
+  applyRotationToMatrix(matrix, xw, rotateXW);
+  applyRotationToMatrix(matrix, yw, rotateYW);
+  applyRotationToMatrix(matrix, zw, rotateZW);
 
-  return m;
+  return matrix;
 }
 
 function applyRotationToMatrix(target: mat4, angle: number, generator: (out: mat4, angle: number) => mat4) {
   if (angle === 0) return;
-  const r = generator(mat4.create(), angle);
+  const r = generator(rotationScratch, angle);
   mat4.multiply(target, r, target);
 }
 
@@ -153,25 +162,219 @@ function rotateZW(out: vec4 | mat4, angle: number): typeof out {
   return out;
 }
 
-export function composeDualQuaternion(angles: RotationAngles) {
-  const { xy, xz, yz, xw, yw, zw } = angles;
-  const left = quaternionFromEuler(xy, xz, yz);
-  const right = quaternionFromEuler(xw, yw, zw);
-  return { left, right };
+const dualQuatMatrixScratch = mat4.create();
+const dualQuatBasis = [
+  vec4.fromValues(0, 0, 0, 1),
+  vec4.fromValues(1, 0, 0, 0),
+  vec4.fromValues(0, 1, 0, 0),
+  vec4.fromValues(0, 0, 1, 0)
+];
+const dualQuatRotated = [vec4.create(), vec4.create(), vec4.create(), vec4.create()];
+const dualQuatMatrixBasis = [
+  vec4.fromValues(1, 0, 0, 0),
+  vec4.fromValues(0, 1, 0, 0),
+  vec4.fromValues(0, 0, 1, 0),
+  vec4.fromValues(0, 0, 0, 1)
+];
+
+function createQuaternion(): [number, number, number, number] {
+  return [0, 0, 0, 0];
 }
 
-function quaternionFromEuler(ax: number, ay: number, az: number): [number, number, number, number] {
-  const cx = Math.cos(ax * 0.5);
-  const sx = Math.sin(ax * 0.5);
-  const cy = Math.cos(ay * 0.5);
-  const sy = Math.sin(ay * 0.5);
-  const cz = Math.cos(az * 0.5);
-  const sz = Math.sin(az * 0.5);
+const dualQuatQuaternions = Array.from({ length: 11 }, createQuaternion);
 
-  return [
-    sx * cy * cz + cx * sy * sz,
-    cx * sy * cz - sx * cy * sz,
-    cx * cy * sz + sx * sy * cz,
-    cx * cy * cz - sx * sy * sz
-  ];
+const tmpVectorQuaternion: [number, number, number, number] = [0, 0, 0, 0];
+const tmpLeftQuat: [number, number, number, number] = [0, 0, 0, 0];
+const tmpRightQuat: [number, number, number, number] = [0, 0, 0, 0];
+const tmpProduct: [number, number, number, number] = [0, 0, 0, 0];
+const tmpConjugateRight: [number, number, number, number] = [0, 0, 0, 0];
+
+export function composeDualQuaternion<L extends QuaternionBuffer = [number, number, number, number], R extends QuaternionBuffer = [number, number, number, number]>(
+  angles: RotationAngles,
+  outLeft?: L,
+  outRight?: R
+): DualQuaternionPair<L, R> {
+  const matrix = rotationMatrixFromAngles(angles, dualQuatMatrixScratch);
+
+  for (let i = 0; i < dualQuatBasis.length; i++) {
+    vec4.transformMat4(dualQuatRotated[i], dualQuatBasis[i], matrix);
+  }
+
+  const quatA = vectorToQuaternionInto(dualQuatRotated[0], dualQuatQuaternions[0]);
+  const quatB = vectorToQuaternionInto(dualQuatRotated[1], dualQuatQuaternions[1]);
+  const quatC = vectorToQuaternionInto(dualQuatRotated[2], dualQuatQuaternions[2]);
+  const quatD = vectorToQuaternionInto(dualQuatRotated[3], dualQuatQuaternions[3]);
+
+  const aConjugate = conjugateQuaternionInto(quatA, dualQuatQuaternions[4]);
+  const rotatedI = multiplyQuaternionsInto(dualQuatQuaternions[5], quatB, aConjugate);
+  const rotatedJ = multiplyQuaternionsInto(dualQuatQuaternions[6], quatC, aConjugate);
+  const rotatedK = multiplyQuaternionsInto(dualQuatQuaternions[7], quatD, aConjugate);
+
+  const leftQuatWFirst = quaternionFromRotationMatrix3(
+    rotatedI[1], rotatedJ[1], rotatedK[1],
+    rotatedI[2], rotatedJ[2], rotatedK[2],
+    rotatedI[3], rotatedJ[3], rotatedK[3],
+    dualQuatQuaternions[8]
+  );
+
+  normalizeQuaternionInPlace(leftQuatWFirst);
+
+  const conjugateLeft = conjugateQuaternionInto(leftQuatWFirst, dualQuatQuaternions[9]);
+  const conjugateRight = multiplyQuaternionsInto(dualQuatQuaternions[10], conjugateLeft, quatA);
+  const rightQuatWFirst = normalizeQuaternionInto(conjugateQuaternionInto(conjugateRight, conjugateRight), conjugateRight);
+
+  const leftResult = (outLeft ?? createQuaternion()) as L;
+  const rightResult = (outRight ?? createQuaternion()) as R;
+
+  quaternionToVectorInto(leftQuatWFirst, leftResult);
+  quaternionToVectorInto(rightQuatWFirst, rightResult);
+
+  return { left: leftResult, right: rightResult };
+}
+
+export function applyDualQuaternionRotation(vector: vec4, angles: RotationAngles, out?: vec4): vec4 {
+  const { left, right } = composeDualQuaternion(angles);
+  return rotateVectorWithDualQuaternion(vector, left, right, out ?? vec4.create());
+}
+
+export function rotationMatrixFromDualQuaternion(angles: RotationAngles): mat4 {
+  const matrix = mat4.create();
+  const { left, right } = composeDualQuaternion(angles);
+  const rotated = vec4.create();
+
+  for (let i = 0; i < dualQuatMatrixBasis.length; i++) {
+    rotateVectorWithDualQuaternion(dualQuatMatrixBasis[i], left, right, rotated);
+    for (let row = 0; row < 4; row++) {
+      matrix[i * 4 + row] = rotated[row];
+    }
+  }
+
+  return matrix;
+}
+
+function rotateVectorWithDualQuaternion(vector: vec4, left: QuaternionBuffer, right: QuaternionBuffer, out: vec4): vec4 {
+  const leftQuat = normalizeQuaternionInto(toWFirst(left, tmpLeftQuat), tmpLeftQuat);
+  const rightQuat = normalizeQuaternionInto(toWFirst(right, tmpRightQuat), tmpRightQuat);
+  const vectorQuat = vectorToQuaternionInto(vector, tmpVectorQuaternion);
+  const product = multiplyQuaternionsInto(tmpProduct, leftQuat, vectorQuat);
+  const conjugateRight = conjugateQuaternionInto(rightQuat, tmpConjugateRight);
+  const rotated = multiplyQuaternionsInto(tmpVectorQuaternion, product, conjugateRight);
+
+  out[0] = rotated[1];
+  out[1] = rotated[2];
+  out[2] = rotated[3];
+  out[3] = rotated[0];
+  return out;
+}
+
+function toWFirst(quaternion: QuaternionBuffer, out: QuaternionBuffer): QuaternionBuffer {
+  out[0] = quaternion[3];
+  out[1] = quaternion[0];
+  out[2] = quaternion[1];
+  out[3] = quaternion[2];
+  return out;
+}
+
+function normalizeQuaternionInto(source: QuaternionBuffer, out: QuaternionBuffer): QuaternionBuffer {
+  const w = source[0];
+  const x = source[1];
+  const y = source[2];
+  const z = source[3];
+  const mag = Math.hypot(w, x, y, z) || 1;
+  out[0] = w / mag;
+  out[1] = x / mag;
+  out[2] = y / mag;
+  out[3] = z / mag;
+  return out;
+}
+
+function normalizeQuaternionInPlace(quaternion: QuaternionBuffer): QuaternionBuffer {
+  return normalizeQuaternionInto(quaternion, quaternion);
+}
+
+function conjugateQuaternionInto(source: QuaternionBuffer, out: QuaternionBuffer): QuaternionBuffer {
+  out[0] = source[0];
+  out[1] = -source[1];
+  out[2] = -source[2];
+  out[3] = -source[3];
+  return out;
+}
+
+function multiplyQuaternionsInto(out: QuaternionBuffer, a: QuaternionBuffer, b: QuaternionBuffer): QuaternionBuffer {
+  const aw = a[0];
+  const ax = a[1];
+  const ay = a[2];
+  const az = a[3];
+  const bw = b[0];
+  const bx = b[1];
+  const by = b[2];
+  const bz = b[3];
+
+  out[0] = aw * bw - ax * bx - ay * by - az * bz;
+  out[1] = aw * bx + ax * bw + ay * bz - az * by;
+  out[2] = aw * by - ax * bz + ay * bw + az * bx;
+  out[3] = aw * bz + ax * by - ay * bx + az * bw;
+  return out;
+}
+
+function vectorToQuaternionInto(vector: vec4, out: QuaternionBuffer): QuaternionBuffer {
+  out[0] = vector[3];
+  out[1] = vector[0];
+  out[2] = vector[1];
+  out[3] = vector[2];
+  return out;
+}
+
+function quaternionToVectorInto(quaternion: QuaternionBuffer, out: QuaternionBuffer): QuaternionBuffer {
+  out[0] = quaternion[1];
+  out[1] = quaternion[2];
+  out[2] = quaternion[3];
+  out[3] = quaternion[0];
+  return out;
+}
+
+function quaternionFromRotationMatrix3(
+  m00: number, m01: number, m02: number,
+  m10: number, m11: number, m12: number,
+  m20: number, m21: number, m22: number,
+  out: QuaternionBuffer
+): QuaternionBuffer {
+  const trace = m00 + m11 + m22;
+
+  let w: number;
+  let x: number;
+  let y: number;
+  let z: number;
+
+  if (trace > 0) {
+    const s = Math.sqrt(trace + 1) * 2;
+    w = 0.25 * s;
+    x = (m21 - m12) / s;
+    y = (m02 - m20) / s;
+    z = (m10 - m01) / s;
+  } else if (m00 > m11 && m00 > m22) {
+    const s = Math.sqrt(1 + m00 - m11 - m22) * 2;
+    w = (m21 - m12) / s;
+    x = 0.25 * s;
+    y = (m01 + m10) / s;
+    z = (m02 + m20) / s;
+  } else if (m11 > m22) {
+    const s = Math.sqrt(1 + m11 - m00 - m22) * 2;
+    w = (m02 - m20) / s;
+    x = (m01 + m10) / s;
+    y = 0.25 * s;
+    z = (m12 + m21) / s;
+  } else {
+    const s = Math.sqrt(1 + m22 - m00 - m11) * 2;
+    w = (m10 - m01) / s;
+    x = (m02 + m20) / s;
+    y = (m12 + m21) / s;
+    z = 0.25 * s;
+  }
+
+  out[0] = w;
+  out[1] = x;
+  out[2] = y;
+  out[3] = z;
+  return normalizeQuaternionInto(out, out);
 }

--- a/src/core/uberShaderBuilder.test.ts
+++ b/src/core/uberShaderBuilder.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { UberShaderBuilder } from './uberShaderBuilder';
+
+describe('UberShaderBuilder', () => {
+  it('concatenates modules with headers', () => {
+    const builder = new UberShaderBuilder();
+    builder.addModule({
+      name: 'geometry',
+      header: '#define ENABLE_GEOMETRY',
+      body: 'vec4 loadGeometry() { return vec4(0.0); }'
+    });
+    builder.addModule({
+      name: 'projection',
+      body: 'vec3 project(vec4 v) { return v.xyz; }'
+    });
+
+    const result = builder.build();
+    expect(result).toContain('#define ENABLE_GEOMETRY');
+    expect(result).toContain('module: projection');
+  });
+});

--- a/src/core/uberShaderBuilder.ts
+++ b/src/core/uberShaderBuilder.ts
@@ -1,0 +1,19 @@
+export interface ShaderModule {
+  name: string;
+  header?: string;
+  body: string;
+}
+
+export class UberShaderBuilder {
+  private readonly modules: ShaderModule[] = [];
+
+  addModule(module: ShaderModule) {
+    this.modules.push(module);
+  }
+
+  build(): string {
+    const header = this.modules.map(module => module.header ?? '').join('\n');
+    const body = this.modules.map(module => `// module: ${module.name}\n${module.body}`).join('\n\n');
+    return `${header}\n${body}`.trim();
+  }
+}

--- a/src/core/uniformSyncQueue.test.ts
+++ b/src/core/uniformSyncQueue.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+import { UniformSyncQueue } from './uniformSyncQueue';
+
+describe('UniformSyncQueue', () => {
+  it('only exposes the latest snapshot per frame', () => {
+    const queue = new UniformSyncQueue();
+    queue.enqueue({ xy: 0.1, xz: 0.2, yz: 0.3, xw: 0, yw: 0, zw: 0, timestamp: 1, confidence: 1 });
+    queue.enqueue({ xy: 0.5, xz: 0.6, yz: 0.7, xw: 0, yw: 0, zw: 0, timestamp: 2, confidence: 1 });
+    const snapshot = queue.consume();
+    expect(snapshot?.xy).toBeCloseTo(0.5);
+    expect(queue.consume()).toBeNull();
+  });
+});

--- a/src/core/uniformSyncQueue.ts
+++ b/src/core/uniformSyncQueue.ts
@@ -1,0 +1,47 @@
+import type { RotationSnapshot } from './rotationUniforms';
+
+export interface UniformSyncMetrics {
+  enqueued: number;
+  uploads: number;
+  skipped: number;
+  lastUploadTime: number;
+  lastSnapshotTimestamp: number;
+  lastUploadLatency: number;
+}
+
+export class UniformSyncQueue {
+  private pending: RotationSnapshot | null = null;
+  private metrics: UniformSyncMetrics = {
+    enqueued: 0,
+    uploads: 0,
+    skipped: 0,
+    lastUploadTime: performance.now(),
+    lastSnapshotTimestamp: 0,
+    lastUploadLatency: 0
+  };
+
+  enqueue(snapshot: RotationSnapshot) {
+    this.metrics.enqueued += 1;
+    if (this.pending) {
+      this.metrics.skipped += 1;
+    }
+    this.pending = { ...snapshot };
+  }
+
+  consume(): RotationSnapshot | null {
+    if (!this.pending) {
+      return null;
+    }
+    const snapshot = this.pending;
+    this.pending = null;
+    this.metrics.uploads += 1;
+    this.metrics.lastUploadTime = performance.now();
+    this.metrics.lastSnapshotTimestamp = snapshot.timestamp;
+    this.metrics.lastUploadLatency = Math.max(0, this.metrics.lastUploadTime - snapshot.timestamp);
+    return snapshot;
+  }
+
+  getMetrics(): UniformSyncMetrics {
+    return { ...this.metrics };
+  }
+}

--- a/src/geometry/geometryTopology.test.ts
+++ b/src/geometry/geometryTopology.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { listGeometries } from '../pipeline/geometryCatalog';
+
+function eulerCharacteristic(topology: { vertices: number; edges: number; faces: number; cells: number }): number {
+  return topology.vertices - topology.edges + topology.faces - topology.cells;
+}
+
+describe('geometry topologies', () => {
+  const geometries = listGeometries();
+
+  it('exposes all required topologies', () => {
+    expect(geometries.length).toBeGreaterThan(0);
+    for (const descriptor of geometries) {
+      expect(descriptor.data.topology.vertices).toBeGreaterThan(0);
+      expect(descriptor.data.topology.edges).toBeGreaterThan(0);
+    }
+  });
+
+  it('has Euler characteristic of zero for regular polychora', () => {
+    for (const descriptor of geometries) {
+      const chi = eulerCharacteristic(descriptor.data.topology);
+      expect(Math.abs(chi)).toBeLessThanOrEqual(1e-9);
+    }
+  });
+});

--- a/src/geometry/sixHundredCell.ts
+++ b/src/geometry/sixHundredCell.ts
@@ -1,0 +1,125 @@
+import { LINE_DRAW_MODE, type GeometryData } from './types';
+
+const PHI = (1 + Math.sqrt(5)) / 2;
+const INV_PHI = 1 / PHI;
+
+function createSixHundredCell(): GeometryData {
+  const vertices: number[][] = [];
+  const seen = new Set<string>();
+
+  function addVertex(v: number[]) {
+    const key = v.map(value => value.toFixed(6)).join(',');
+    if (!seen.has(key)) {
+      seen.add(key);
+      vertices.push(v);
+    }
+  }
+
+  // 16 hypercube vertices (±1/2, ±1/2, ±1/2, ±1/2)
+  for (const sx of [-0.5, 0.5]) {
+    for (const sy of [-0.5, 0.5]) {
+      for (const sz of [-0.5, 0.5]) {
+        for (const sw of [-0.5, 0.5]) {
+          addVertex([sx, sy, sz, sw]);
+        }
+      }
+    }
+  }
+
+  // 8 cross-polytope vertices (±1, 0, 0, 0)
+  for (let axis = 0; axis < 4; axis++) {
+    for (const sign of [-1, 1]) {
+      const v = [0, 0, 0, 0];
+      v[axis] = sign;
+      addVertex(v);
+    }
+  }
+
+  // 96 permutations of (0, ±1/2, ±phi/2, ±1/(2phi))
+  const base = [0, 0.5, PHI / 2, INV_PHI / 2];
+  const permutations = generatePermutations([0, 1, 2, 3]);
+
+  for (const perm of permutations) {
+    const components = perm.map(index => base[index]);
+    const nonZeroIndices = components
+      .map((value, index) => (Math.abs(value) > 1e-6 ? index : -1))
+      .filter(index => index >= 0);
+
+    const signCombos = 1 << nonZeroIndices.length;
+    for (let mask = 0; mask < signCombos; mask++) {
+      const candidate = components.slice();
+      let signParity = 1;
+      for (let bit = 0; bit < nonZeroIndices.length; bit++) {
+        const idx = nonZeroIndices[bit];
+        const sign = (mask & (1 << bit)) ? -1 : 1;
+        candidate[idx] *= sign;
+        signParity *= sign;
+      }
+
+      // Only accept configurations with even sign parity to enforce 96 vertices
+      if (signParity > 0) {
+        addVertex(candidate);
+      }
+    }
+  }
+
+  if (vertices.length !== 120) {
+    throw new Error(`600-cell vertex generation failed (expected 120, got ${vertices.length})`);
+  }
+
+  const candidates: Array<{ a: number; b: number; distance: number }> = [];
+  for (let i = 0; i < vertices.length; i++) {
+    for (let j = i + 1; j < vertices.length; j++) {
+      candidates.push({ a: i, b: j, distance: distanceSquared(vertices[i], vertices[j]) });
+    }
+  }
+
+  candidates.sort((a, b) => a.distance - b.distance);
+
+  const indices: number[] = [];
+  for (let k = 0; k < 720; k++) {
+    const edge = candidates[k];
+    indices.push(edge.a, edge.b);
+  }
+
+  if (indices.length / 2 !== 720) {
+    throw new Error(`600-cell edge generation failed (expected 720, got ${indices.length / 2})`);
+  }
+
+  return {
+    positions: new Float32Array(vertices.flat()),
+    indices: new Uint16Array(indices),
+    drawMode: LINE_DRAW_MODE,
+    vertexStride: 4,
+    topology: {
+      vertices: 120,
+      edges: 720,
+      faces: 1200,
+      cells: 600
+    }
+  };
+}
+
+function generatePermutations(indices: number[]): number[][] {
+  if (indices.length === 1) return [indices.slice()];
+  const permutations: number[][] = [];
+  for (let i = 0; i < indices.length; i++) {
+    const [current] = indices.splice(i, 1);
+    for (const rest of generatePermutations(indices)) {
+      permutations.push([current, ...rest]);
+    }
+    indices.splice(i, 0, current);
+  }
+  return permutations;
+}
+
+function distanceSquared(a: number[], b: number[]): number {
+  let sum = 0;
+  for (let i = 0; i < 4; i++) {
+    const d = a[i] - b[i];
+    sum += d * d;
+  }
+  return sum;
+}
+
+export const SixHundredCellGeometry = createSixHundredCell();

--- a/src/geometry/tesseract.ts
+++ b/src/geometry/tesseract.ts
@@ -1,4 +1,4 @@
-import type { GeometryData } from './types';
+import { LINE_DRAW_MODE, type GeometryData } from './types';
 
 function createTesseractGeometry(): GeometryData {
   const vertices: number[][] = [];
@@ -35,8 +35,14 @@ function createTesseractGeometry(): GeometryData {
   return {
     positions: new Float32Array(vertices.flat()),
     indices: new Uint16Array(indices),
-    drawMode: WebGL2RenderingContext.LINES,
-    vertexStride: 4
+    drawMode: LINE_DRAW_MODE,
+    vertexStride: 4,
+    topology: {
+      vertices: vertices.length,
+      edges: indices.length / 2,
+      faces: 24,
+      cells: 8
+    }
   };
 }
 

--- a/src/geometry/twentyFourCell.ts
+++ b/src/geometry/twentyFourCell.ts
@@ -1,4 +1,4 @@
-import type { GeometryData } from './types';
+import { LINE_DRAW_MODE, type GeometryData } from './types';
 
 function createTwentyFourCell(): GeometryData {
   const vertices: number[][] = [];
@@ -37,8 +37,14 @@ function createTwentyFourCell(): GeometryData {
   return {
     positions: new Float32Array(vertices.flat()),
     indices: new Uint16Array(indices),
-    drawMode: WebGL2RenderingContext.LINES,
-    vertexStride: 4
+    drawMode: LINE_DRAW_MODE,
+    vertexStride: 4,
+    topology: {
+      vertices: vertices.length,
+      edges: indices.length / 2,
+      faces: 96,
+      cells: 24
+    }
   };
 }
 

--- a/src/geometry/types.ts
+++ b/src/geometry/types.ts
@@ -1,8 +1,16 @@
+export interface GeometryTopology {
+  vertices: number;
+  edges: number;
+  faces: number;
+  cells: number;
+}
+
 export interface GeometryData {
   positions: Float32Array;
   indices: Uint16Array;
   drawMode: number;
   vertexStride: number;
+  topology: GeometryTopology;
 }
 
 export interface GeometryDescriptor {
@@ -10,3 +18,5 @@ export interface GeometryDescriptor {
   name: string;
   data: GeometryData;
 }
+
+export const LINE_DRAW_MODE = 0x0001;

--- a/src/ingestion/extrumentHub.test.ts
+++ b/src/ingestion/extrumentHub.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { RotationSnapshot } from '../core/rotationUniforms';
+import { ExtrumentHub, normalizeSnapshot, describeSnapshot, type ExtrumentAdapter } from './extrumentHub';
+
+const baseSnapshot: RotationSnapshot = {
+  xy: Math.PI / 4,
+  xz: -Math.PI / 6,
+  yz: Math.PI / 8,
+  xw: -Math.PI / 3,
+  yw: 0.2,
+  zw: -0.15,
+  timestamp: 42,
+  confidence: 0.9
+};
+
+describe('normalizeSnapshot', () => {
+  it('normalizes angles into 0..1 range with default clamp', () => {
+    const normalized = normalizeSnapshot(baseSnapshot);
+    expect(normalized.planes.xy).toBeCloseTo(0.5 + 0.5 * (baseSnapshot.xy / Math.PI), 5);
+    expect(normalized.planes.xz).toBeLessThan(0.5);
+    expect(normalized.timestamp).toBe(baseSnapshot.timestamp);
+    expect(normalized.raw.xy).toBe(baseSnapshot.xy);
+  });
+
+  it('respects unclamped mode', () => {
+    const snapshot = { ...baseSnapshot, xy: Math.PI * 2 };
+    const normalized = normalizeSnapshot(snapshot, { clamp: false });
+    expect(normalized.planes.xy).toBeGreaterThan(1);
+  });
+
+  it('reports magnitude as mean absolute angle', () => {
+    const normalized = normalizeSnapshot(baseSnapshot);
+    const manual =
+      (Math.abs(baseSnapshot.xy) +
+        Math.abs(baseSnapshot.xz) +
+        Math.abs(baseSnapshot.yz) +
+        Math.abs(baseSnapshot.xw) +
+        Math.abs(baseSnapshot.yw) +
+        Math.abs(baseSnapshot.zw)) /
+      6;
+    expect(normalized.magnitude).toBeCloseTo(manual, 6);
+  });
+
+  it('describes snapshot with concise summary', () => {
+    const normalized = normalizeSnapshot(baseSnapshot);
+    const summary = describeSnapshot(normalized);
+    expect(summary).toContain('σ=');
+    expect(summary).toContain('xy:');
+  });
+});
+
+describe('ExtrumentHub', () => {
+  const createAdapter = (id: string): ExtrumentAdapter<number> => ({
+    id,
+    connect: vi.fn().mockResolvedValue(undefined),
+    disconnect: vi.fn().mockResolvedValue(undefined),
+    send: vi.fn().mockResolvedValue(undefined)
+  });
+
+  it('registers adapters and broadcasts transformed payloads', async () => {
+    const adapter = createAdapter('alpha');
+    const hub = new ExtrumentHub<number>({
+      transform: (snapshot) => Math.round(snapshot.xy * 100)
+    });
+    hub.register(adapter);
+    await hub.connect('alpha');
+    await hub.broadcast(baseSnapshot);
+    expect(adapter.send).toHaveBeenCalledWith(Math.round(baseSnapshot.xy * 100));
+  });
+
+  it('disconnects adapters that throw during send and surfaces errors', async () => {
+    const adapter = createAdapter('beta');
+    const error = new Error('failed');
+    (adapter.send as ReturnType<typeof vi.fn>).mockRejectedValueOnce(error);
+    const onError = vi.fn();
+    const hub = new ExtrumentHub<number>({ transform: () => 0, onError });
+    hub.register(adapter);
+    await hub.connect('beta');
+    await hub.broadcast(baseSnapshot);
+    expect(onError).toHaveBeenCalledWith(error, adapter);
+  });
+
+  it('throws when connecting unknown adapters', async () => {
+    const hub = new ExtrumentHub();
+    await expect(hub.connect('missing')).rejects.toThrow('Unknown adapter');
+  });
+});

--- a/src/ingestion/extrumentHub.ts
+++ b/src/ingestion/extrumentHub.ts
@@ -1,0 +1,141 @@
+import type { RotationSnapshot } from '../core/rotationUniforms';
+import { SIX_PLANE_KEYS } from '../core/sixPlaneOrbit';
+
+type PlaneKey = (typeof SIX_PLANE_KEYS)[number];
+
+export interface ExtrumentAdapter<TPayload = RotationSnapshot> {
+  readonly id: string;
+  connect(): Promise<void> | void;
+  disconnect(): Promise<void> | void;
+  send(payload: TPayload): Promise<void> | void;
+  isConnected?(): boolean;
+}
+
+export interface ExtrumentHubOptions<TPayload> {
+  transform?: (snapshot: RotationSnapshot) => TPayload;
+  onError?: (error: unknown, adapter: ExtrumentAdapter<TPayload>) => void;
+}
+
+interface AdapterState<TPayload> {
+  adapter: ExtrumentAdapter<TPayload>;
+  connected: boolean;
+}
+
+export class ExtrumentHub<TPayload = RotationSnapshot> {
+  private readonly adapters = new Map<string, AdapterState<TPayload>>();
+  private readonly transform: (snapshot: RotationSnapshot) => TPayload;
+  private readonly onError?: (error: unknown, adapter: ExtrumentAdapter<TPayload>) => void;
+
+  constructor(options: ExtrumentHubOptions<TPayload> = {}) {
+    this.transform = options.transform ?? ((snapshot) => snapshot as unknown as TPayload);
+    this.onError = options.onError;
+  }
+
+  register(adapter: ExtrumentAdapter<TPayload>): () => void {
+    if (this.adapters.has(adapter.id)) {
+      throw new Error(`Adapter with id ${adapter.id} is already registered`);
+    }
+    this.adapters.set(adapter.id, { adapter, connected: false });
+    return () => {
+      const entry = this.adapters.get(adapter.id);
+      if (!entry) return;
+      if (entry.connected) {
+        void entry.adapter.disconnect();
+      }
+      this.adapters.delete(adapter.id);
+    };
+  }
+
+  async connect(id: string): Promise<void> {
+    const entry = this.adapters.get(id);
+    if (!entry) {
+      throw new Error(`Unknown adapter ${id}`);
+    }
+    if (entry.connected) return;
+    await entry.adapter.connect();
+    entry.connected = entry.adapter.isConnected ? entry.adapter.isConnected() ?? true : true;
+  }
+
+  async disconnect(id: string): Promise<void> {
+    const entry = this.adapters.get(id);
+    if (!entry) return;
+    if (!entry.connected) return;
+    await entry.adapter.disconnect();
+    entry.connected = entry.adapter.isConnected ? entry.adapter.isConnected() ?? false : false;
+  }
+
+  async broadcast(snapshot: RotationSnapshot): Promise<void> {
+    if (this.adapters.size === 0) return;
+    const payload = this.transform(snapshot);
+    await this.broadcastPayload(payload);
+  }
+
+  async broadcastPayload(payload: TPayload): Promise<void> {
+    if (this.adapters.size === 0) return;
+    for (const state of this.adapters.values()) {
+      if (!state.connected) continue;
+      try {
+        await state.adapter.send(payload);
+      } catch (error) {
+        state.connected = state.adapter.isConnected ? state.adapter.isConnected() ?? false : false;
+        if (this.onError) {
+          this.onError(error, state.adapter);
+        }
+      }
+    }
+  }
+
+  listAdapters(): Array<{ id: string; connected: boolean }> {
+    return Array.from(this.adapters.values()).map(({ adapter, connected }) => ({
+      id: adapter.id,
+      connected
+    }));
+  }
+}
+
+export interface NormalizedSnapshot {
+  timestamp: number;
+  confidence: number;
+  magnitude: number;
+  planes: Record<PlaneKey, number>;
+  raw: RotationSnapshot;
+}
+
+export interface NormalizeOptions {
+  range?: number;
+  clamp?: boolean;
+}
+
+export function normalizeSnapshot(snapshot: RotationSnapshot, options: NormalizeOptions = {}): NormalizedSnapshot {
+  const range = options.range ?? Math.PI;
+  const clamp = options.clamp ?? true;
+  const planes = {} as Record<PlaneKey, number>;
+  let magnitude = 0;
+
+  for (const plane of SIX_PLANE_KEYS) {
+    const value = snapshot[plane];
+    magnitude += Math.abs(value);
+    let normalized = range === 0 ? 0 : value / range;
+    if (clamp) {
+      normalized = Math.min(1, Math.max(-1, normalized));
+    }
+    planes[plane] = normalized * 0.5 + 0.5;
+  }
+
+  magnitude /= SIX_PLANE_KEYS.length;
+
+  return {
+    timestamp: snapshot.timestamp,
+    confidence: snapshot.confidence,
+    magnitude,
+    planes,
+    raw: { ...snapshot }
+  };
+}
+
+export function describeSnapshot(snapshot: NormalizedSnapshot): string {
+  const planeSummary = SIX_PLANE_KEYS
+    .map((plane) => `${plane}:${snapshot.planes[plane].toFixed(2)}`)
+    .join(' ');
+  return `σ=${snapshot.magnitude.toFixed(2)} · c=${snapshot.confidence.toFixed(2)} · ${planeSummary}`;
+}

--- a/src/ingestion/midiExtrument.test.ts
+++ b/src/ingestion/midiExtrument.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from 'vitest';
+import { MidiExtrumentAdapter, discoverMidiAdapters, type MidiOutputLike } from './midiExtrument';
+import { type NormalizedSnapshot } from './extrumentHub';
+
+const snapshot: NormalizedSnapshot = {
+  timestamp: 100,
+  confidence: 0.8,
+  magnitude: 0.5,
+  planes: { xy: 0.1, xz: 0.2, yz: 0.3, xw: 0.4, yw: 0.5, zw: 0.6 },
+  raw: {
+    xy: 0,
+    xz: 0,
+    yz: 0,
+    xw: 0,
+    yw: 0,
+    zw: 0,
+    timestamp: 100,
+    confidence: 0.8
+  }
+};
+
+describe('MidiExtrumentAdapter', () => {
+  it('sends control change messages for each plane', async () => {
+    const sent: (number[] | Uint8Array)[] = [];
+    const output: MidiOutputLike = {
+      id: 'out-1',
+      send: (message) => {
+        if (!message) return;
+        sent.push(message);
+      }
+    };
+    const adapter = new MidiExtrumentAdapter({ output });
+    await adapter.connect();
+    await adapter.send(snapshot);
+    expect(sent).toHaveLength(8); // 6 planes + magnitude + confidence
+    const first = Array.from(sent[0]);
+    expect(first[1]).toBe(20);
+    expect(first[2]).toBeGreaterThanOrEqual(0);
+    expect(adapter.label).toBe('out-1');
+  });
+});
+
+describe('discoverMidiAdapters', () => {
+  it('selects the first output by default', async () => {
+    const outputs: MidiOutputLike[] = [
+      { id: 'first', send: vi.fn() },
+      { id: 'second', send: vi.fn() }
+    ];
+    const adapters = await discoverMidiAdapters({
+      accessFactory: async () => ({ outputs })
+    });
+    expect(adapters).toHaveLength(1);
+    expect(adapters[0].id).toBe('midi:first');
+  });
+
+  it('returns empty list when selector rejects outputs', async () => {
+    const adapters = await discoverMidiAdapters({
+      accessFactory: async () => ({ outputs: [] }),
+      selectOutput: () => undefined
+    });
+    expect(adapters).toHaveLength(0);
+  });
+});

--- a/src/ingestion/midiExtrument.ts
+++ b/src/ingestion/midiExtrument.ts
@@ -1,0 +1,109 @@
+import { SIX_PLANE_KEYS } from '../core/sixPlaneOrbit';
+import type { ExtrumentAdapter, NormalizedSnapshot } from './extrumentHub';
+
+export interface MidiOutputLike {
+  id: string;
+  name?: string;
+  send(message?: number[] | Uint8Array, timestamp?: number): void;
+}
+
+export interface MidiExtrumentOptions {
+  output: MidiOutputLike;
+  channel?: number;
+  controlChangeMap?: number[];
+  magnitudeCc?: number;
+  confidenceCc?: number;
+}
+
+function clampMidi(value: number): number {
+  if (Number.isNaN(value)) return 0;
+  return Math.min(127, Math.max(0, Math.round(value)));
+}
+
+function toMidiValue(normalized: number): number {
+  return clampMidi(normalized * 127);
+}
+
+export class MidiExtrumentAdapter implements ExtrumentAdapter<NormalizedSnapshot> {
+  readonly id: string;
+  readonly label: string;
+  private readonly output: MidiOutputLike;
+  private readonly channel: number;
+  private readonly ccMap: number[];
+  private readonly magnitudeCc?: number;
+  private readonly confidenceCc?: number;
+  private connected = false;
+
+  constructor(options: MidiExtrumentOptions) {
+    this.output = options.output;
+    this.id = `midi:${options.output.id}`;
+    this.label = options.output.name ?? options.output.id;
+    this.channel = Math.min(15, Math.max(0, Math.floor(options.channel ?? 0)));
+    this.ccMap = options.controlChangeMap ?? [20, 21, 22, 23, 24, 25];
+    this.magnitudeCc = options.magnitudeCc ?? 26;
+    this.confidenceCc = options.confidenceCc ?? 27;
+  }
+
+  isConnected(): boolean {
+    return this.connected;
+  }
+
+  async connect(): Promise<void> {
+    this.connected = true;
+  }
+
+  async disconnect(): Promise<void> {
+    this.connected = false;
+  }
+
+  async send(snapshot: NormalizedSnapshot): Promise<void> {
+    if (!this.connected) return;
+    const status = 0xb0 | this.channel;
+    const values = SIX_PLANE_KEYS.map((plane) => toMidiValue(snapshot.planes[plane]));
+    for (let i = 0; i < Math.min(this.ccMap.length, values.length); i++) {
+      this.output.send([status, this.ccMap[i], values[i]], snapshot.timestamp);
+    }
+    if (this.magnitudeCc !== undefined) {
+      this.output.send([status, this.magnitudeCc, clampMidi(snapshot.magnitude * 127)], snapshot.timestamp);
+    }
+    if (this.confidenceCc !== undefined) {
+      this.output.send([status, this.confidenceCc, clampMidi(snapshot.confidence * 127)], snapshot.timestamp);
+    }
+  }
+}
+
+type MidiAccessLike = {
+  outputs: Iterable<MidiOutputLike> | Map<string, MidiOutputLike>;
+};
+
+type MidiAccessFactory = () => Promise<MidiAccessLike>;
+
+function resolveOutputs(collection: MidiAccessLike['outputs']): MidiOutputLike[] {
+  if (collection instanceof Map) {
+    return Array.from(collection.values());
+  }
+  if (Symbol.iterator in Object(collection)) {
+    return Array.from(collection as Iterable<MidiOutputLike>);
+  }
+  return [];
+}
+
+export interface MidiDiscoveryOptions {
+  accessFactory: MidiAccessFactory;
+  selectOutput?: (outputs: MidiOutputLike[]) => MidiOutputLike | undefined;
+}
+
+export async function discoverMidiAdapters(
+  options: MidiDiscoveryOptions
+): Promise<MidiExtrumentAdapter[]> {
+  const access = await options.accessFactory();
+  const outputs = resolveOutputs(access.outputs);
+  const select = options.selectOutput ?? ((list: MidiOutputLike[]) => list[0]);
+  const chosen = select(outputs);
+  if (!chosen) return [];
+  return [
+    new MidiExtrumentAdapter({
+      output: chosen
+    })
+  ];
+}

--- a/src/ingestion/parserator.test.ts
+++ b/src/ingestion/parserator.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ImuPacket } from './imuMapper';
+import { Parserator, gravityIsolation } from './parserator';
+import type { PlaneMappingProfile } from './profiles';
+
+const basePacket: ImuPacket = {
+  timestamp: 1_000,
+  gyro: [0.5, -0.25, 0.75],
+  accel: [0.1, 0.2, 0.3],
+  confidence: 0.2
+};
+
+const identityProfile: PlaneMappingProfile = {
+  id: 'identity',
+  name: 'Identity passthrough',
+  spatial: [
+    { axis: 'x', plane: 'xy', gain: 1, smoothing: 0 },
+    { axis: 'y', plane: 'xz', gain: 1, smoothing: 0 },
+    { axis: 'z', plane: 'yz', gain: 1, smoothing: 0 }
+  ],
+  hyperspatial: [
+    { axis: 'x', plane: 'xw', gain: 1, smoothing: 0 },
+    { axis: 'y', plane: 'yw', gain: 1, smoothing: 0 },
+    { axis: 'z', plane: 'zw', gain: 1, smoothing: 0 }
+  ]
+};
+
+describe('Parserator', () => {
+  it('applies preprocessors and enforces the confidence floor', () => {
+    const parserator = new Parserator({ profile: identityProfile, confidenceFloor: 0.6 });
+    const preprocessor = vi.fn((packet: ImuPacket): ImuPacket => ({
+      ...packet,
+      gyro: [1, 2, 3] as [number, number, number]
+    }));
+    parserator.registerPreprocessor(preprocessor, { id: 'mock-preprocessor' });
+
+    const listener = vi.fn();
+    parserator.onSnapshot(listener);
+
+    parserator.ingest(basePacket);
+
+    expect(preprocessor).toHaveBeenCalled();
+    expect(listener).toHaveBeenCalledTimes(1);
+    const snapshot = listener.mock.calls[0][0];
+    expect(snapshot.xy).toBeCloseTo(1, 6);
+    expect(snapshot.xz).toBeCloseTo(2, 6);
+    expect(snapshot.yz).toBeCloseTo(3, 6);
+    expect(snapshot.confidence).toBeCloseTo(0.6, 6);
+  });
+
+  it('supports unregistering preprocessors via disposer', () => {
+    const parserator = new Parserator({ profile: identityProfile });
+    const preprocessor = vi.fn((packet: ImuPacket) => packet);
+    const registration = parserator.registerPreprocessor(preprocessor, { id: 'disposable' });
+
+    parserator.ingest({ ...basePacket, timestamp: 2_000 });
+    registration.dispose();
+    parserator.ingest({ ...basePacket, timestamp: 3_000 });
+
+    expect(preprocessor).toHaveBeenCalledTimes(1);
+    expect(parserator.listPreprocessors()).not.toContain('disposable');
+  });
+
+  it('switches mapping profiles at runtime', () => {
+    const parserator = new Parserator({ profile: identityProfile });
+    const listener = vi.fn();
+    parserator.onSnapshot(listener);
+
+    parserator.ingest({ ...basePacket, timestamp: 4_000 });
+
+    const remappedProfile: PlaneMappingProfile = {
+      id: 'remap',
+      name: 'Remapped planes',
+      spatial: [
+        { axis: 'x', plane: 'yz', gain: 2, smoothing: 0 },
+        { axis: 'y', plane: 'xy', gain: 0.5, smoothing: 0 },
+        { axis: 'z', plane: 'xz', gain: 1.5, smoothing: 0 }
+      ],
+      hyperspatial: identityProfile.hyperspatial
+    };
+
+    parserator.setProfile(remappedProfile);
+    listener.mockClear();
+
+    const packet: ImuPacket = {
+      timestamp: 5_000,
+      gyro: [0.4, -0.6, 0.2],
+      accel: [0.3, 0.1, 0.5]
+    };
+
+    parserator.ingest(packet);
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    const snapshot = listener.mock.calls[0][0];
+    expect(snapshot.yz).toBeCloseTo(0.8, 6);
+    expect(snapshot.xy).toBeCloseTo(-0.3, 6);
+    expect(snapshot.xz).toBeCloseTo(0.3, 6);
+  });
+
+  it('allows updating the confidence floor dynamically', () => {
+    const parserator = new Parserator({ profile: identityProfile, confidenceFloor: 0.1 });
+    const listener = vi.fn();
+    parserator.onSnapshot(listener);
+
+    parserator.ingest({ ...basePacket, confidence: 0.05, timestamp: 6_000 });
+    parserator.setConfidenceFloor(0.9);
+    parserator.ingest({ ...basePacket, confidence: 0.2, timestamp: 7_000 });
+
+    const [, second] = listener.mock.calls;
+    expect(second[0].confidence).toBeCloseTo(0.9, 6);
+  });
+
+  it('composes preprocessors with gravity isolation helper', () => {
+    const parserator = new Parserator({ profile: identityProfile });
+    const listener = vi.fn();
+    parserator.onSnapshot(listener);
+
+    parserator.registerPreprocessor(gravityIsolation(0.5), { id: 'gravity' });
+
+    const packet: ImuPacket = {
+      timestamp: 8_000,
+      gyro: [0, 0, 0],
+      accel: [0, 0, 1]
+    };
+
+    parserator.ingest(packet);
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    const snapshot = listener.mock.calls[0][0];
+    expect(snapshot.xw).toBeCloseTo(0, 6);
+    expect(snapshot.yw).toBeCloseTo(0, 6);
+    expect(snapshot.zw).toBeCloseTo(0.5, 6);
+    expect(parserator.listPreprocessors()).toContain('gravity');
+  });
+
+  it('reports current profile metadata and confidence floor', () => {
+    const parserator = new Parserator({ profile: identityProfile, confidenceFloor: 0.42 });
+    expect(parserator.getProfile().id).toBe('identity');
+    expect(parserator.getConfidenceFloor()).toBeCloseTo(0.42);
+
+    const alternate: PlaneMappingProfile = {
+      id: 'alternate',
+      name: 'Alternate Profile',
+      spatial: identityProfile.spatial,
+      hyperspatial: identityProfile.hyperspatial
+    };
+
+    parserator.setProfile(alternate);
+    parserator.setConfidenceFloor(0.73);
+
+    expect(parserator.getProfile().id).toBe('alternate');
+    expect(parserator.getConfidenceFloor()).toBeCloseTo(0.73);
+  });
+});

--- a/src/ingestion/parserator.ts
+++ b/src/ingestion/parserator.ts
@@ -1,0 +1,183 @@
+import { mapImuPacket, type ImuPacket } from './imuMapper';
+import type { RotationSnapshot } from '../core/rotationUniforms';
+import type { PlaneMappingProfile } from './profiles';
+import { DEFAULT_PROFILE } from './profiles';
+
+export type Preprocessor = (packet: ImuPacket) => ImuPacket;
+export type SnapshotListener = (snapshot: RotationSnapshot) => void;
+
+export interface PreprocessorOptions {
+  id?: string;
+}
+
+export interface PreprocessorRegistration {
+  id: string;
+  dispose: () => void;
+}
+
+export interface ParseratorOptions {
+  profile?: PlaneMappingProfile;
+  confidenceFloor?: number;
+}
+
+export class Parserator {
+  private preprocessors: Array<{ id: string; handler: Preprocessor }> = [];
+  private listeners = new Set<SnapshotListener>();
+  private lastTimestamp = 0;
+  private profile: PlaneMappingProfile;
+  private confidenceFloor: number;
+  private preprocessorCounter = 0;
+
+  constructor(options: ParseratorOptions = {}) {
+    this.profile = options.profile ?? DEFAULT_PROFILE;
+    this.confidenceFloor = options.confidenceFloor ?? 0.6;
+  }
+
+  registerPreprocessor(fn: Preprocessor, options: PreprocessorOptions = {}): PreprocessorRegistration {
+    const id = options.id ?? `preprocessor-${++this.preprocessorCounter}`;
+    this.preprocessors.push({ id, handler: fn });
+    return {
+      id,
+      dispose: () => {
+        const index = this.preprocessors.findIndex(entry => entry.id === id);
+        if (index >= 0) {
+          this.preprocessors.splice(index, 1);
+        }
+      }
+    };
+  }
+
+  onSnapshot(listener: SnapshotListener) {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  setProfile(profile: PlaneMappingProfile): void {
+    this.profile = profile;
+  }
+
+  setConfidenceFloor(confidence: number): void {
+    this.confidenceFloor = confidence;
+  }
+
+  getProfile(): PlaneMappingProfile {
+    return this.profile;
+  }
+
+  getConfidenceFloor(): number {
+    return this.confidenceFloor;
+  }
+
+  listPreprocessors(): string[] {
+    return this.preprocessors.map(entry => entry.id);
+  }
+
+  ingest(packet: ImuPacket) {
+    let processed = packet;
+    for (const entry of this.preprocessors) {
+      processed = entry.handler(processed);
+    }
+
+    const dt = this.computeDelta(processed.timestamp);
+    const snapshot = mapImuPacket(processed, dt);
+    snapshot.confidence = Math.max(snapshot.confidence, this.confidenceFloor);
+    this.applyProfile(snapshot, processed);
+
+    for (const listener of this.listeners) {
+      listener({ ...snapshot });
+    }
+  }
+
+  private computeDelta(timestamp: number): number {
+    if (this.lastTimestamp === 0) {
+      this.lastTimestamp = timestamp;
+      return 0.016;
+    }
+    const dt = Math.max(1e-3, (timestamp - this.lastTimestamp) / 1000);
+    this.lastTimestamp = timestamp;
+    return dt;
+  }
+
+  private applyProfile(snapshot: RotationSnapshot, packet: ImuPacket) {
+    const axisIndex = { x: 0, y: 1, z: 2 } as const;
+
+    for (const channel of this.profile.spatial) {
+      const index = axisIndex[channel.axis];
+      const value = packet.gyro[index] * channel.gain;
+      snapshot[channel.plane] = this.applySmoothing(snapshot[channel.plane], value, channel.smoothing);
+      if (channel.clamp !== undefined) {
+        snapshot[channel.plane] = clamp(snapshot[channel.plane], -channel.clamp, channel.clamp);
+      }
+    }
+
+    for (const channel of this.profile.hyperspatial) {
+      const index = axisIndex[channel.axis];
+      const value = packet.accel[index] * channel.gain;
+      snapshot[channel.plane] = this.applySmoothing(snapshot[channel.plane], value, channel.smoothing);
+      if (channel.clamp !== undefined) {
+        snapshot[channel.plane] = clamp(snapshot[channel.plane], -channel.clamp, channel.clamp);
+      }
+    }
+  }
+
+  private applySmoothing(current: number, incoming: number, smoothing = 0): number {
+    if (smoothing <= 0) return incoming;
+    return current * smoothing + incoming * (1 - smoothing);
+  }
+}
+
+export function lowPassGyro(cutoff: number): Preprocessor {
+  let last: ImuPacket | null = null;
+  return packet => {
+    if (!last) {
+      last = packet;
+      return packet;
+    }
+    const blend = Math.exp(-cutoff * Math.max(1e-3, (packet.timestamp - last.timestamp) / 1000));
+    const gyro: [number, number, number] = [0, 0, 0];
+    for (let i = 0; i < 3; i++) {
+      gyro[i] = blend * last.gyro[i] + (1 - blend) * packet.gyro[i];
+    }
+    last = { ...packet, gyro };
+    return last;
+  };
+}
+
+export function gravityIsolation(strength: number): Preprocessor {
+  return packet => {
+    const [ax, ay, az] = packet.accel;
+    const magnitude = Math.max(Math.hypot(ax, ay, az), 1e-5);
+    const normalized: [number, number, number] = [ax / magnitude, ay / magnitude, az / magnitude];
+    return { ...packet, accel: normalized.map(value => value * strength) as [number, number, number] };
+  };
+}
+
+export function featureWindow(windowSize: number): Preprocessor {
+  const window: ImuPacket[] = [];
+  return packet => {
+    window.push(packet);
+    if (window.length > windowSize) window.shift();
+    const averaged = averagePackets(window);
+    return { ...packet, gyro: averaged.gyro, accel: averaged.accel };
+  };
+}
+
+function averagePackets(samples: ImuPacket[]): { gyro: [number, number, number]; accel: [number, number, number] } {
+  const gyro: [number, number, number] = [0, 0, 0];
+  const accel: [number, number, number] = [0, 0, 0];
+  for (const sample of samples) {
+    for (let i = 0; i < 3; i++) {
+      gyro[i] += sample.gyro[i];
+      accel[i] += sample.accel[i];
+    }
+  }
+  for (let i = 0; i < 3; i++) {
+    gyro[i] /= samples.length;
+    accel[i] /= samples.length;
+  }
+  return { gyro, accel };
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}

--- a/src/ingestion/profiles.test.ts
+++ b/src/ingestion/profiles.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { AVAILABLE_PROFILES, DEFAULT_PROFILE, getProfileById } from './profiles';
+
+describe('profiles', () => {
+  it('exposes the default profile in the registry', () => {
+    const profile = getProfileById(DEFAULT_PROFILE.id);
+    expect(profile?.name).toBe(DEFAULT_PROFILE.name);
+  });
+
+  it('returns undefined for unknown profile ids', () => {
+    expect(getProfileById('missing-profile')).toBeUndefined();
+  });
+
+  it('lists profiles in a deterministic order', () => {
+    const ids = AVAILABLE_PROFILES.map(profile => profile.id);
+    const sorted = [...ids].sort();
+    expect(ids).toEqual(sorted);
+  });
+});

--- a/src/ingestion/profiles.ts
+++ b/src/ingestion/profiles.ts
@@ -1,0 +1,73 @@
+import type { RotationAngles } from '../core/rotationUniforms';
+
+export type RotationPlane = keyof RotationAngles;
+
+export interface MappingChannel {
+  axis: 'x' | 'y' | 'z';
+  plane: RotationPlane;
+  gain: number;
+  clamp?: number;
+  smoothing?: number;
+}
+
+export interface PlaneMappingProfile {
+  id: string;
+  name: string;
+  spatial: MappingChannel[];
+  hyperspatial: MappingChannel[];
+}
+
+export const DEFAULT_PROFILE: PlaneMappingProfile = {
+  id: 'default-imu',
+  name: 'Default IMU',
+  spatial: [
+    { axis: 'x', plane: 'yz', gain: 1.0, smoothing: 0.1 },
+    { axis: 'y', plane: 'xz', gain: 0.95, smoothing: 0.1 },
+    { axis: 'z', plane: 'xy', gain: 0.9, smoothing: 0.1 }
+  ],
+  hyperspatial: [
+    { axis: 'x', plane: 'xw', gain: 0.35, smoothing: 0.2 },
+    { axis: 'y', plane: 'yw', gain: 0.35, smoothing: 0.2 },
+    { axis: 'z', plane: 'zw', gain: 0.35, smoothing: 0.2 }
+  ]
+};
+
+export const SMOOTHING_PROFILE: PlaneMappingProfile = {
+  id: 'smooth-orbit',
+  name: 'Smooth Orbit',
+  spatial: [
+    { axis: 'x', plane: 'yz', gain: 0.85, smoothing: 0.45 },
+    { axis: 'y', plane: 'xz', gain: 0.8, smoothing: 0.45 },
+    { axis: 'z', plane: 'xy', gain: 0.82, smoothing: 0.45 }
+  ],
+  hyperspatial: [
+    { axis: 'x', plane: 'xw', gain: 0.28, smoothing: 0.55 },
+    { axis: 'y', plane: 'yw', gain: 0.28, smoothing: 0.55 },
+    { axis: 'z', plane: 'zw', gain: 0.28, smoothing: 0.55 }
+  ]
+};
+
+export const HIGH_GAIN_PROFILE: PlaneMappingProfile = {
+  id: 'high-gain-imu',
+  name: 'High Gain',
+  spatial: [
+    { axis: 'x', plane: 'yz', gain: 1.35, clamp: 2.8, smoothing: 0.08 },
+    { axis: 'y', plane: 'xz', gain: 1.25, clamp: 2.8, smoothing: 0.08 },
+    { axis: 'z', plane: 'xy', gain: 1.2, clamp: 2.6, smoothing: 0.08 }
+  ],
+  hyperspatial: [
+    { axis: 'x', plane: 'xw', gain: 0.48, clamp: 1.4, smoothing: 0.2 },
+    { axis: 'y', plane: 'yw', gain: 0.48, clamp: 1.4, smoothing: 0.2 },
+    { axis: 'z', plane: 'zw', gain: 0.48, clamp: 1.4, smoothing: 0.2 }
+  ]
+};
+
+export const AVAILABLE_PROFILES: PlaneMappingProfile[] = [
+  DEFAULT_PROFILE,
+  HIGH_GAIN_PROFILE,
+  SMOOTHING_PROFILE
+];
+
+export function getProfileById(id: string): PlaneMappingProfile | undefined {
+  return AVAILABLE_PROFILES.find(profile => profile.id === id);
+}

--- a/src/ingestion/replayHarness.ts
+++ b/src/ingestion/replayHarness.ts
@@ -1,0 +1,24 @@
+import type { ImuPacket } from './imuMapper';
+import { Parserator, type ParseratorOptions } from './parserator';
+
+export interface ReplayOptions extends ParseratorOptions {
+  tickIntervalMs?: number;
+}
+
+export function replayDataset(packets: ImuPacket[], options: ReplayOptions = {}) {
+  const parserator = new Parserator(options);
+  const interval = options.tickIntervalMs ?? 16;
+
+  let index = 0;
+  function dispatchNext() {
+    if (index >= packets.length) return;
+    parserator.ingest(packets[index]);
+    index += 1;
+    if (index < packets.length) {
+      setTimeout(dispatchNext, interval);
+    }
+  }
+
+  dispatchNext();
+  return parserator;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,47 @@
 import { HypercubeCore } from './core/hypercubeCore';
-import { ZERO_ROTATION, type RotationAngles, type RotationSnapshot } from './core/rotationUniforms';
+import {
+  rotationEnergy,
+  ZERO_ROTATION,
+  type RotationAngles,
+  type RotationSnapshot
+} from './core/rotationUniforms';
 import { createHarmonicOrbit, SIX_PLANE_KEYS } from './core/sixPlaneOrbit';
-import { getGeometry, type GeometryId } from './pipeline/geometryCatalog';
+import { type GeometryId } from './pipeline/geometryCatalog';
 import { RotationBus } from './pipeline/rotationBus';
+import { GeometryController } from './pipeline/geometryController';
+import { DatasetExportService } from './pipeline/datasetExport';
+import {
+  DatasetManifestBuilder,
+  DATASET_MANIFEST_STORAGE_KEY,
+  createManifestDownloadName,
+  type DatasetManifest
+} from './pipeline/datasetManifest';
+import { LocalPspStream } from './pipeline/pspStream';
+import { FocusDirector } from './pipeline/focusDirector';
+import { LatencyTracker } from './pipeline/latencyTracker';
+import {
+  ExtrumentHub,
+  normalizeSnapshot,
+  describeSnapshot,
+  type NormalizedSnapshot
+} from './ingestion/extrumentHub';
+import { discoverMidiAdapters } from './ingestion/midiExtrument';
+import {
+  Parserator,
+  gravityIsolation,
+  lowPassGyro,
+  featureWindow,
+  type PreprocessorRegistration,
+  type Preprocessor
+} from './ingestion/parserator';
+import { AVAILABLE_PROFILES, DEFAULT_PROFILE, getProfileById } from './ingestion/profiles';
+import { TelemetryLoom } from './pipeline/telemetryLoom';
+import {
+  ConfidenceTrend,
+  DATASET_CONFIDENCE_TREND_STORAGE_KEY,
+  type ConfidenceTrendAnnotation,
+  type ConfidenceTrendState
+} from './pipeline/confidenceTrend';
 
 const canvas = document.getElementById('gl-canvas') as HTMLCanvasElement;
 const statusEl = document.getElementById('status') as HTMLParagraphElement;
@@ -10,18 +49,244 @@ const geometrySelect = document.getElementById('geometry') as HTMLSelectElement;
 const projectionDepthSlider = document.getElementById('projectionDepth') as HTMLInputElement;
 const lineWidthSlider = document.getElementById('lineWidth') as HTMLInputElement;
 const rotationControlsContainer = document.getElementById('rotation-controls') as HTMLDivElement;
+const uniformUploadsEl = document.getElementById('uniform-uploads') as HTMLSpanElement;
+const uniformSkipsEl = document.getElementById('uniform-skips') as HTMLSpanElement;
+const datasetPendingEl = document.getElementById('dataset-pending') as HTMLSpanElement;
+const datasetTotalEl = document.getElementById('dataset-total') as HTMLSpanElement;
+const uniformLatencyEl = document.getElementById('uniform-latency') as HTMLSpanElement;
+const captureLatencyEl = document.getElementById('capture-latency') as HTMLSpanElement;
+const encodeLatencyEl = document.getElementById('encode-latency') as HTMLSpanElement;
+const datasetFormatEl = document.getElementById('dataset-format') as HTMLSpanElement;
+const manifestFramesEl = document.getElementById('manifest-frames') as HTMLSpanElement;
+const manifestP95El = document.getElementById('manifest-p95') as HTMLSpanElement;
+const manifestConfidenceEl = document.getElementById('manifest-confidence') as HTMLSpanElement;
+const manifestUpdatedEl = document.getElementById('manifest-updated') as HTMLSpanElement;
+const manifestConfidenceTrendCanvas = document.getElementById('manifest-confidence-trend') as HTMLCanvasElement;
+const manifestDownloadButton = document.getElementById('manifest-download') as HTMLButtonElement;
+const parseratorProfileNameEl = document.getElementById('parserator-profile-name') as HTMLSpanElement;
+const parseratorProfileSelect = document.getElementById('parserator-profile-select') as HTMLSelectElement;
+const parseratorConfidenceValueEl = document.getElementById('parserator-confidence-value') as HTMLSpanElement;
+const parseratorConfidenceInput = document.getElementById('parserator-confidence-input') as HTMLInputElement;
+const parseratorPreprocessorsEl = document.getElementById('parserator-preprocessors') as HTMLSpanElement;
+const parseratorPreprocessorContainer = document.getElementById('parserator-preprocessor-controls') as HTMLDivElement;
+const extrumentStatusEl = document.getElementById('extrument-status') as HTMLSpanElement;
+const extrumentOutputEl = document.getElementById('extrument-output') as HTMLSpanElement;
+const extrumentPayloadEl = document.getElementById('extrument-payload') as HTMLSpanElement;
+const extrumentConnectButton = document.getElementById('extrument-connect') as HTMLButtonElement;
+const telemetryCountEl = document.getElementById('telemetry-count') as HTMLSpanElement;
+const telemetryEventsEl = document.getElementById('telemetry-events') as HTMLUListElement;
 
-if (!canvas || !statusEl || !geometrySelect || !projectionDepthSlider || !lineWidthSlider || !rotationControlsContainer) {
+if (
+  !canvas ||
+  !statusEl ||
+  !geometrySelect ||
+  !projectionDepthSlider ||
+  !lineWidthSlider ||
+  !rotationControlsContainer ||
+  !uniformUploadsEl ||
+  !uniformSkipsEl ||
+  !datasetPendingEl ||
+  !datasetTotalEl ||
+  !uniformLatencyEl ||
+  !captureLatencyEl ||
+  !encodeLatencyEl ||
+  !datasetFormatEl ||
+  !manifestFramesEl ||
+  !manifestP95El ||
+  !manifestDownloadButton ||
+  !manifestConfidenceEl ||
+  !manifestUpdatedEl ||
+  !manifestConfidenceTrendCanvas ||
+  !parseratorProfileNameEl ||
+  !parseratorProfileSelect ||
+  !parseratorConfidenceValueEl ||
+  !parseratorConfidenceInput ||
+  !parseratorPreprocessorsEl ||
+  !parseratorPreprocessorContainer ||
+  !extrumentStatusEl ||
+  !extrumentOutputEl ||
+  !extrumentPayloadEl ||
+  !extrumentConnectButton ||
+  !telemetryCountEl ||
+  !telemetryEventsEl
+) {
   throw new Error('Required DOM nodes are missing');
 }
+
+const manifestConfidenceTrendCtx = (() => {
+  const context = manifestConfidenceTrendCanvas.getContext('2d');
+  if (!context) {
+    throw new Error('Unable to create manifest confidence trend context');
+  }
+  return context;
+})();
 
 const core = new HypercubeCore(canvas, {
   projectionDepth: Number(projectionDepthSlider.value),
   lineWidth: Number(lineWidthSlider.value)
 });
 
+const geometryController = new GeometryController(core);
 const rotationBus = new RotationBus();
 rotationBus.subscribe(snapshot => core.updateRotation(snapshot));
+const latencyTracker = new LatencyTracker();
+const datasetExport = new DatasetExportService({
+  onLatencySample: latency => latencyTracker.recordEncode(latency)
+});
+
+let persistedManifest: DatasetManifest | undefined;
+try {
+  if (typeof localStorage !== 'undefined') {
+    const raw = localStorage.getItem(DATASET_MANIFEST_STORAGE_KEY);
+    if (raw) {
+      persistedManifest = JSON.parse(raw) as DatasetManifest;
+    }
+  }
+} catch (error) {
+  console.warn('Failed to load dataset manifest', error);
+}
+
+let persistedTrendState: ConfidenceTrendState | undefined = persistedManifest?.confidenceTrend;
+try {
+  if (typeof localStorage !== 'undefined') {
+    const rawTrend = localStorage.getItem(DATASET_CONFIDENCE_TREND_STORAGE_KEY);
+    if (rawTrend) {
+      persistedTrendState = JSON.parse(rawTrend) as ConfidenceTrendState;
+    }
+  }
+} catch (error) {
+  console.warn('Failed to load confidence trend', error);
+}
+
+const manifestBuilder = new DatasetManifestBuilder({ hydrateFrom: persistedManifest });
+const pspStream = new LocalPspStream();
+const focusDirector = new FocusDirector(geometryController, rotationBus, { fallbackGeometry: 'tesseract' });
+const MAX_PENDING_FRAMES = 48;
+const CONFIDENCE_TREND_POINTS = 60;
+
+const confidenceTrend = new ConfidenceTrend({
+  maxPoints: CONFIDENCE_TREND_POINTS,
+  state: persistedTrendState
+});
+let lastManifestUpdateSample = confidenceTrend.getUpdatedAt() ?? 0;
+
+const extrumentHub = new ExtrumentHub<NormalizedSnapshot>({
+  transform: normalizeSnapshot,
+  onError: (error, adapter) => {
+    console.warn('Extrument adapter error', error);
+    extrumentStatusEl.textContent = `Error · ${adapter.id}`;
+    extrumentConnected = false;
+    extrumentConnectButton.disabled = false;
+  }
+});
+const extrumentAdapterLabels = new Map<string, string>();
+let extrumentConnected = false;
+const extrumentDisconnectors: Array<() => void> = [];
+
+const parserator = new Parserator();
+const telemetryLoom = new TelemetryLoom(180);
+if (persistedManifest?.telemetry) {
+  telemetryLoom.hydrate(persistedManifest.telemetry);
+}
+const TELEMETRY_DISPLAY_LIMIT = 24;
+
+type PreprocessorOption = {
+  id: string;
+  label: string;
+  description: string;
+  factory: () => Preprocessor;
+};
+
+const PREPROCESSOR_OPTIONS: PreprocessorOption[] = [
+  {
+    id: 'low-pass',
+    label: 'Low-pass gyro',
+    description: 'Smooths gyro spikes with an adaptive exponential filter.',
+    factory: () => lowPassGyro(6)
+  },
+  {
+    id: 'gravity',
+    label: 'Gravity isolation',
+    description: 'Normalises acceleration vectors to isolate orientation cues.',
+    factory: () => gravityIsolation(0.85)
+  },
+  {
+    id: 'feature-window',
+    label: 'Feature window',
+    description: 'Averages the last eight samples to reduce jitter before mapping.',
+    factory: () => featureWindow(8)
+  }
+];
+
+const preprocessorHandles = new Map<string, PreprocessorRegistration>();
+const preprocessorCheckboxes = new Map<string, HTMLInputElement>();
+const preprocessorLookup = new Map(PREPROCESSOR_OPTIONS.map(option => [option.id, option]));
+
+rotationBus.subscribe(snapshot => {
+  const normalized = normalizeSnapshot(snapshot);
+  lastExtrumentSummary = describeSnapshot(normalized);
+  extrumentPayloadEl.textContent = lastExtrumentSummary;
+  void extrumentHub.broadcastPayload(normalized);
+});
+
+populateParseratorProfiles();
+renderParseratorPreprocessors();
+renderTelemetry();
+
+const hydratedIngestion = persistedManifest?.ingestion;
+if (hydratedIngestion) {
+  const profile = getProfileById(hydratedIngestion.profileId) ?? DEFAULT_PROFILE;
+  parserator.setProfile(profile);
+  parserator.setConfidenceFloor(hydratedIngestion.confidenceFloor);
+  for (const id of hydratedIngestion.preprocessors) {
+    const option = preprocessorLookup.get(id);
+    if (option) {
+      setPreprocessorState(option, true, false);
+    }
+  }
+  logParseratorEvent('Hydrated parserator config', {
+    profile: profile.name,
+    profileId: profile.id,
+    confidence: parserator.getConfidenceFloor(),
+    preprocessors: hydratedIngestion.preprocessors.map(
+      value => preprocessorLookup.get(value)?.label ?? value
+    )
+  });
+} else {
+  parserator.setProfile(DEFAULT_PROFILE);
+  logParseratorEvent('Parserator initialised', {
+    profile: DEFAULT_PROFILE.name,
+    profileId: DEFAULT_PROFILE.id,
+    confidence: parserator.getConfidenceFloor(),
+    preprocessors: []
+  });
+}
+
+parseratorProfileSelect.addEventListener('change', event => {
+  const target = event.target as HTMLSelectElement;
+  const profile = getProfileById(target.value) ?? DEFAULT_PROFILE;
+  parserator.setProfile(profile);
+  updateParseratorTelemetry();
+  persistIngestionConfig();
+  logParseratorEvent('Profile selected', {
+    profile: profile.name,
+    profileId: profile.id
+  });
+});
+
+parseratorConfidenceInput.addEventListener('input', () => {
+  setConfidenceFloor(Number(parseratorConfidenceInput.value), false);
+});
+
+parseratorConfidenceInput.addEventListener('change', () => {
+  setConfidenceFloor(Number(parseratorConfidenceInput.value), true);
+});
+
+updateParseratorTelemetry();
+
+if (!hydratedIngestion) {
+  persistIngestionConfig();
+}
 
 const rotationState: RotationSnapshot = {
   ...ZERO_ROTATION,
@@ -33,21 +298,542 @@ const manualOffsets: RotationAngles = { ...ZERO_ROTATION };
 const autoAngles: RotationAngles = { ...ZERO_ROTATION };
 
 let updateRotationLabels: (combined: RotationAngles, manual: RotationAngles) => void;
+let lastExtrumentSummary = '–';
 
 function pushRotationSnapshot(timestamp: number) {
   rotationState.timestamp = timestamp;
 
-  let energy = 0;
   for (const plane of SIX_PLANE_KEYS) {
     rotationState[plane] = autoAngles[plane] + manualOffsets[plane];
-    energy += Math.abs(rotationState[plane]);
   }
+
+  const energy = rotationEnergy(rotationState);
 
   const normalized = Math.min(1, energy / (Math.PI * SIX_PLANE_KEYS.length));
   rotationState.confidence = 0.75 + 0.25 * (1 - normalized);
 
   rotationBus.push({ ...rotationState });
   updateRotationLabels(rotationState, manualOffsets);
+  updateTelemetry();
+}
+
+function formatLatency(avg: number, max: number) {
+  if (avg <= 0 && max <= 0) {
+    return '0 ms';
+  }
+  return `${avg.toFixed(1)} ms (max ${max.toFixed(1)})`;
+}
+
+function updateManifestTelemetry() {
+  manifestBuilder.updateConfidenceTrend(confidenceTrend.toJSON());
+  const manifest = manifestBuilder.getManifest();
+  manifestFramesEl.textContent = manifest.stats.totalFrames.toString();
+  manifestP95El.textContent =
+    manifest.stats.totalFrames && manifest.stats.p95TotalLatencyMs
+      ? `${manifest.stats.p95TotalLatencyMs.toFixed(1)} ms`
+      : '–';
+  manifestDownloadButton.disabled = manifest.stats.totalFrames === 0;
+
+  const lastUpdated = manifest.stats.lastUpdated || 0;
+  manifestUpdatedEl.textContent = lastUpdated ? formatUpdatedTimestamp(lastUpdated) : '–';
+
+  const histogram = manifest.stats.confidenceHistogram;
+  let ratio: number | null = null;
+  let highConfidence = 0;
+  if (histogram) {
+    const bucketSize = histogram.bucketSize || 0.1;
+    const thresholdIndex = Math.min(
+      histogram.counts.length - 1,
+      Math.max(0, Math.ceil(0.9 / bucketSize) - 1)
+    );
+    highConfidence = histogram.counts
+      .slice(thresholdIndex)
+      .reduce((sum, value) => sum + value, 0);
+    if (histogram.totalSamples > 0) {
+      ratio = highConfidence / histogram.totalSamples;
+    } else if (manifest.stats.totalFrames > 0) {
+      ratio = 0;
+    }
+  }
+
+  if (ratio !== null) {
+    const percentage = Math.round(ratio * 100);
+    manifestConfidenceEl.textContent = `${percentage}% · ${highConfidence}`;
+  } else {
+    manifestConfidenceEl.textContent = '–';
+  }
+
+  const isNewSample = lastUpdated > 0 && lastUpdated !== lastManifestUpdateSample;
+  let trendChanged = false;
+
+  if (manifest.stats.totalFrames === 0) {
+    if (!confidenceTrend.isEmpty()) {
+      confidenceTrend.clear();
+      trendChanged = true;
+    }
+  } else if (isNewSample && ratio !== null) {
+    confidenceTrend.record(ratio, lastUpdated, createParseratorTrendAnnotation());
+    trendChanged = true;
+  }
+
+  renderConfidenceTrend();
+
+  if (trendChanged) {
+    persistConfidenceTrend();
+  }
+
+  if (isNewSample) {
+    lastManifestUpdateSample = lastUpdated;
+  }
+}
+
+function persistManifest() {
+  try {
+    manifestBuilder.updateConfidenceTrend(confidenceTrend.toJSON());
+    manifestBuilder.updateTelemetry(telemetryLoom.snapshot());
+    if (typeof localStorage === 'undefined') {
+      return;
+    }
+    const manifest = manifestBuilder.getManifest();
+    localStorage.setItem(DATASET_MANIFEST_STORAGE_KEY, JSON.stringify(manifest));
+    persistConfidenceTrend();
+  } catch (error) {
+    console.warn('Failed to persist dataset manifest', error);
+  }
+}
+
+function persistConfidenceTrend() {
+  try {
+    if (typeof localStorage === 'undefined') {
+      return;
+    }
+    const payload = confidenceTrend.toJSON();
+    if (!payload.samples || payload.samples.length === 0) {
+      localStorage.removeItem(DATASET_CONFIDENCE_TREND_STORAGE_KEY);
+      return;
+    }
+    localStorage.setItem(DATASET_CONFIDENCE_TREND_STORAGE_KEY, JSON.stringify(payload));
+  } catch (error) {
+    console.warn('Failed to persist confidence trend', error);
+  }
+}
+
+function renderConfidenceTrend() {
+  const width = manifestConfidenceTrendCanvas.clientWidth;
+  const height = manifestConfidenceTrendCanvas.clientHeight;
+  if (width === 0 || height === 0) {
+    return;
+  }
+
+  const dpr = window.devicePixelRatio || 1;
+  const actualWidth = Math.max(1, Math.round(width * dpr));
+  const actualHeight = Math.max(1, Math.round(height * dpr));
+  if (
+    manifestConfidenceTrendCanvas.width !== actualWidth ||
+    manifestConfidenceTrendCanvas.height !== actualHeight
+  ) {
+    manifestConfidenceTrendCanvas.width = actualWidth;
+    manifestConfidenceTrendCanvas.height = actualHeight;
+  }
+
+  manifestConfidenceTrendCtx.setTransform(1, 0, 0, 1, 0, 0);
+  manifestConfidenceTrendCtx.clearRect(0, 0, actualWidth, actualHeight);
+  manifestConfidenceTrendCtx.setTransform(dpr, 0, 0, dpr, 0, 0);
+
+  manifestConfidenceTrendCtx.fillStyle = 'rgba(12, 18, 32, 0.35)';
+  manifestConfidenceTrendCtx.fillRect(0, 0, width, height);
+
+  // Reference line at 90% confidence
+  manifestConfidenceTrendCtx.strokeStyle = 'rgba(127, 210, 255, 0.25)';
+  manifestConfidenceTrendCtx.lineWidth = 1;
+  const ninetyLine = height - height * 0.9;
+  manifestConfidenceTrendCtx.beginPath();
+  manifestConfidenceTrendCtx.moveTo(0, ninetyLine);
+  manifestConfidenceTrendCtx.lineTo(width, ninetyLine);
+  manifestConfidenceTrendCtx.stroke();
+
+  const values = confidenceTrend.getValues();
+  if (!values.length) {
+    manifestConfidenceTrendCtx.fillStyle = 'rgba(211, 246, 255, 0.6)';
+    manifestConfidenceTrendCtx.font =
+      '10px "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace';
+    manifestConfidenceTrendCtx.textBaseline = 'middle';
+    manifestConfidenceTrendCtx.fillText('No samples', 8, height / 2);
+    return;
+  }
+
+  const step = values.length > 1 ? width / (values.length - 1) : width;
+  const points = values.map((ratio, index) => ({
+    x: values.length === 1 ? width : index * step,
+    y: height - ratio * height
+  }));
+
+  manifestConfidenceTrendCtx.lineWidth = 1.5;
+  manifestConfidenceTrendCtx.strokeStyle = 'rgba(127, 210, 255, 0.9)';
+  manifestConfidenceTrendCtx.beginPath();
+  if (points.length === 1) {
+    const point = points[0];
+    manifestConfidenceTrendCtx.moveTo(0, point.y);
+    manifestConfidenceTrendCtx.lineTo(point.x, point.y);
+  } else {
+    manifestConfidenceTrendCtx.moveTo(points[0].x, points[0].y);
+    for (let i = 1; i < points.length; i++) {
+      manifestConfidenceTrendCtx.lineTo(points[i].x, points[i].y);
+    }
+  }
+  manifestConfidenceTrendCtx.stroke();
+
+  manifestConfidenceTrendCtx.fillStyle = 'rgba(127, 210, 255, 0.22)';
+  manifestConfidenceTrendCtx.beginPath();
+  manifestConfidenceTrendCtx.moveTo(0, height);
+  if (points.length === 1) {
+    const point = points[0];
+    manifestConfidenceTrendCtx.lineTo(0, point.y);
+    manifestConfidenceTrendCtx.lineTo(point.x, point.y);
+  } else {
+    manifestConfidenceTrendCtx.lineTo(points[0].x, points[0].y);
+    for (let i = 1; i < points.length; i++) {
+      manifestConfidenceTrendCtx.lineTo(points[i].x, points[i].y);
+    }
+  }
+  manifestConfidenceTrendCtx.lineTo(width, height);
+  manifestConfidenceTrendCtx.closePath();
+  manifestConfidenceTrendCtx.fill();
+
+  const latest = points[points.length - 1];
+  manifestConfidenceTrendCtx.fillStyle = 'rgba(127, 210, 255, 0.85)';
+  manifestConfidenceTrendCtx.beginPath();
+  manifestConfidenceTrendCtx.arc(latest.x, latest.y, 3, 0, Math.PI * 2);
+  manifestConfidenceTrendCtx.fill();
+}
+
+function formatUpdatedTimestamp(timestamp: number): string {
+  const formattedTime = new Date(timestamp).toLocaleTimeString([], {
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit'
+  });
+  return `${formattedTime} · ${formatRelativeTime(timestamp)}`;
+}
+
+function formatRelativeTime(timestamp: number): string {
+  const now = Date.now();
+  const diff = now - timestamp;
+  if (!Number.isFinite(diff) || diff < 0) {
+    return 'just now';
+  }
+  if (diff < 5_000) {
+    return 'just now';
+  }
+  const seconds = Math.floor(diff / 1_000);
+  if (seconds < 60) {
+    return `${seconds}s ago`;
+  }
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) {
+    const rem = seconds % 60;
+    return rem ? `${minutes}m ${rem}s ago` : `${minutes}m ago`;
+  }
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) {
+    const rem = minutes % 60;
+    return rem ? `${hours}h ${rem}m ago` : `${hours}h ago`;
+  }
+  const days = Math.floor(hours / 24);
+  const remHours = hours % 24;
+  return remHours ? `${days}d ${remHours}h ago` : `${days}d ago`;
+}
+
+function logParseratorEvent(message: string, metadata?: Record<string, unknown>) {
+  telemetryLoom.record({ category: 'parserator', message, metadata });
+  renderTelemetry();
+  persistManifest();
+}
+
+function renderTelemetry() {
+  const events = telemetryLoom.list();
+  telemetryCountEl.textContent = `${events.length} events`;
+  telemetryEventsEl.innerHTML = '';
+
+  const recent = events.slice(-TELEMETRY_DISPLAY_LIMIT).reverse();
+  for (const event of recent) {
+    const item = document.createElement('li');
+    item.dataset.category = event.category;
+
+    const textWrapper = document.createElement('div');
+    textWrapper.className = 'telemetry-text';
+
+    const message = document.createElement('span');
+    message.className = 'telemetry-message';
+    message.textContent = event.message;
+    textWrapper.appendChild(message);
+
+    if (event.metadata && Object.keys(event.metadata).length) {
+      const metadata = document.createElement('span');
+      metadata.className = 'telemetry-metadata';
+      metadata.textContent = formatTelemetryMetadata(event.metadata);
+      textWrapper.appendChild(metadata);
+    }
+
+    const timestamp = document.createElement('time');
+    timestamp.className = 'telemetry-timestamp';
+    timestamp.dateTime = new Date(event.timestamp).toISOString();
+    timestamp.textContent = formatEventTimestamp(event.timestamp);
+
+    item.appendChild(textWrapper);
+    item.appendChild(timestamp);
+    telemetryEventsEl.appendChild(item);
+  }
+
+  if (!recent.length) {
+    const empty = document.createElement('li');
+    empty.className = 'telemetry-empty';
+    empty.textContent = 'No parserator events yet';
+    telemetryEventsEl.appendChild(empty);
+  }
+}
+
+function formatTelemetryMetadata(metadata: Record<string, unknown>): string {
+  return Object.entries(metadata)
+    .map(([key, value]) => `${key}: ${formatMetadataValue(value)}`)
+    .join(' · ');
+}
+
+function formatMetadataValue(value: unknown): string {
+  if (Array.isArray(value)) {
+    return value.length ? value.join(', ') : 'none';
+  }
+  if (typeof value === 'number') {
+    if (value >= 0 && value <= 1) {
+      return value.toFixed(2);
+    }
+    return Number.isInteger(value) ? value.toString() : value.toFixed(2);
+  }
+  if (typeof value === 'boolean') {
+    return value ? 'true' : 'false';
+  }
+  return String(value);
+}
+
+function formatEventTimestamp(timestamp: number): string {
+  const date = new Date(timestamp);
+  return date.toLocaleTimeString([], { hour12: false, hour: '2-digit', minute: '2-digit', second: '2-digit' });
+}
+
+function populateParseratorProfiles() {
+  parseratorProfileSelect.innerHTML = '';
+  for (const profile of AVAILABLE_PROFILES) {
+    const option = document.createElement('option');
+    option.value = profile.id;
+    option.textContent = profile.name;
+    parseratorProfileSelect.appendChild(option);
+  }
+}
+
+function renderParseratorPreprocessors() {
+  parseratorPreprocessorContainer.innerHTML = '';
+  preprocessorCheckboxes.clear();
+
+  for (const option of PREPROCESSOR_OPTIONS) {
+    const label = document.createElement('label');
+    label.className = 'parserator-toggle';
+
+    const checkbox = document.createElement('input');
+    checkbox.type = 'checkbox';
+    checkbox.value = option.id;
+    checkbox.addEventListener('change', () => {
+      setPreprocessorState(option, checkbox.checked);
+    });
+
+    const textContainer = document.createElement('div');
+    const title = document.createElement('span');
+    title.textContent = option.label;
+    const hint = document.createElement('small');
+    hint.textContent = option.description;
+    textContainer.appendChild(title);
+    textContainer.appendChild(hint);
+
+    label.appendChild(checkbox);
+    label.appendChild(textContainer);
+    parseratorPreprocessorContainer.appendChild(label);
+    preprocessorCheckboxes.set(option.id, checkbox);
+  }
+}
+
+function setPreprocessorState(option: PreprocessorOption, enabled: boolean, persist = true) {
+  const current = preprocessorHandles.get(option.id);
+  if (enabled && !current) {
+    const registration = parserator.registerPreprocessor(option.factory(), { id: option.id });
+    preprocessorHandles.set(option.id, registration);
+  } else if (!enabled && current) {
+    current.dispose();
+    preprocessorHandles.delete(option.id);
+  }
+
+  updateParseratorTelemetry();
+
+  if (persist) {
+    logParseratorEvent(`${enabled ? 'Enabled' : 'Disabled'} ${option.label}`, {
+      preprocessorId: option.id,
+      enabled
+    });
+    persistIngestionConfig();
+  }
+}
+
+function setConfidenceFloor(value: number, persist = true) {
+  const clamped = Math.min(1, Math.max(0, Number.isFinite(value) ? value : parserator.getConfidenceFloor()));
+  parserator.setConfidenceFloor(clamped);
+  updateParseratorTelemetry();
+  if (persist) {
+    logParseratorEvent('Confidence floor updated', { confidence: clamped });
+    persistIngestionConfig();
+  }
+}
+
+function persistIngestionConfig() {
+  const profile = parserator.getProfile();
+  manifestBuilder.updateIngestionConfig({
+    profileId: profile.id,
+    profileName: profile.name,
+    confidenceFloor: parserator.getConfidenceFloor(),
+    preprocessors: parserator.listPreprocessors()
+  });
+  persistManifest();
+}
+
+function createParseratorTrendAnnotation(): ConfidenceTrendAnnotation {
+  const profile = parserator.getProfile();
+  return {
+    profileId: profile.id,
+    profileName: profile.name,
+    confidenceFloor: parserator.getConfidenceFloor(),
+    preprocessors: parserator.listPreprocessors()
+  };
+}
+
+function updateParseratorTelemetry() {
+  const profile = parserator.getProfile();
+  parseratorProfileNameEl.textContent = profile.name;
+  parseratorProfileSelect.value = profile.id;
+
+  const confidence = parserator.getConfidenceFloor();
+  parseratorConfidenceValueEl.textContent = confidence.toFixed(2);
+  parseratorConfidenceInput.value = confidence.toFixed(2);
+
+  const activeIds = parserator.listPreprocessors();
+  if (!activeIds.length) {
+    parseratorPreprocessorsEl.textContent = '–';
+  } else {
+    parseratorPreprocessorsEl.textContent = activeIds
+      .map(id => preprocessorLookup.get(id)?.label ?? id)
+      .join(', ');
+  }
+
+  for (const [id, checkbox] of preprocessorCheckboxes) {
+    checkbox.checked = preprocessorHandles.has(id);
+  }
+}
+
+function updateTelemetry() {
+  const uniformMetrics = core.getUniformMetrics();
+  uniformUploadsEl.textContent = `${uniformMetrics.uploads}/${uniformMetrics.enqueued}`;
+  uniformSkipsEl.textContent = uniformMetrics.skipped.toString();
+  latencyTracker.recordUniform(uniformMetrics);
+
+  const pipelineLatency = latencyTracker.getMetrics();
+  uniformLatencyEl.textContent = formatLatency(pipelineLatency.uniformAvgMs, pipelineLatency.uniformMaxMs);
+  captureLatencyEl.textContent = formatLatency(pipelineLatency.captureAvgMs, pipelineLatency.captureMaxMs);
+  encodeLatencyEl.textContent = formatLatency(pipelineLatency.encodeAvgMs, pipelineLatency.encodeMaxMs);
+
+  const datasetMetrics = datasetExport.getMetrics();
+  datasetPendingEl.textContent = datasetMetrics.pending.toString();
+  datasetTotalEl.textContent = datasetMetrics.totalEncoded.toString();
+  datasetFormatEl.textContent = datasetMetrics.lastFormat ?? '–';
+  updateManifestTelemetry();
+}
+
+async function connectExtruments() {
+  if (extrumentConnected) {
+    updateExtrumentStatus();
+    return;
+  }
+
+  extrumentConnectButton.disabled = true;
+  extrumentStatusEl.textContent = 'Scanning MIDI…';
+
+  try {
+    const navigatorWithMidi = navigator as Navigator & { requestMIDIAccess?: () => Promise<any> };
+    if (!navigatorWithMidi.requestMIDIAccess) {
+      extrumentStatusEl.textContent = 'WebMIDI unavailable';
+      extrumentConnectButton.disabled = false;
+      return;
+    }
+
+    const adapters = await discoverMidiAdapters({
+      accessFactory: async () => {
+        const access = await navigatorWithMidi.requestMIDIAccess!();
+        return {
+          outputs: Array.from(access.outputs.values()).map(output => ({
+            id: output.id,
+            name: output.name ?? undefined,
+            send: (message?: number[] | Uint8Array, timestamp?: number) => {
+              const payload = message ?? [];
+              output.send(payload, timestamp);
+            }
+          }))
+        };
+      }
+    });
+
+    if (!adapters.length) {
+      extrumentStatusEl.textContent = 'No MIDI outputs found';
+      extrumentConnectButton.disabled = false;
+      return;
+    }
+
+    extrumentDisconnectors.forEach(dispose => dispose());
+    extrumentDisconnectors.length = 0;
+
+    for (const adapter of adapters) {
+      extrumentAdapterLabels.set(adapter.id, adapter.label ?? adapter.id);
+      const dispose = extrumentHub.register(adapter);
+      extrumentDisconnectors.push(dispose);
+      await extrumentHub.connect(adapter.id);
+    }
+
+    extrumentConnected = true;
+    extrumentStatusEl.textContent = `Connected · ${adapters.length}`;
+    extrumentConnectButton.textContent = 'MIDI Connected';
+    extrumentConnectButton.disabled = true;
+    updateExtrumentStatus();
+    extrumentPayloadEl.textContent = lastExtrumentSummary;
+  } catch (error) {
+    console.error('Failed to connect extruments', error);
+    extrumentStatusEl.textContent = 'Connection failed';
+    extrumentConnectButton.disabled = false;
+  }
+}
+
+function updateExtrumentStatus() {
+  const states = extrumentHub.listAdapters();
+  if (!states.length) {
+    extrumentStatusEl.textContent = extrumentConnected ? 'Connected' : 'Idle';
+    if (!extrumentConnected) {
+      extrumentOutputEl.textContent = '–';
+    }
+    return;
+  }
+  const connected = states.filter(state => state.connected);
+  if (connected.length) {
+    extrumentStatusEl.textContent = `Connected · ${connected.length}`;
+  } else {
+    extrumentStatusEl.textContent = 'Ready';
+  }
+  const labels = states
+    .map(state => extrumentAdapterLabels.get(state.id) ?? state.id.replace(/^midi:/, ''))
+    .join(', ');
+  extrumentOutputEl.textContent = labels || '–';
 }
 
 updateRotationLabels = createRotationControls(rotationControlsContainer, manualOffsets, () => {
@@ -56,12 +842,41 @@ updateRotationLabels = createRotationControls(rotationControlsContainer, manualO
 
 pushRotationSnapshot(performance.now());
 
+extrumentConnectButton.addEventListener('click', () => {
+  void connectExtruments();
+});
+
+manifestDownloadButton.addEventListener('click', downloadManifest);
+
+updateExtrumentStatus();
+updateManifestTelemetry();
+renderConfidenceTrend();
+
+window.addEventListener('beforeunload', () => {
+  extrumentDisconnectors.forEach(dispose => dispose());
+});
+
+window.addEventListener('resize', () => {
+  renderConfidenceTrend();
+});
+
+function populateGeometryOptions() {
+  const geometries = geometryController.getAvailableGeometries();
+  geometrySelect.innerHTML = '';
+  for (const descriptor of geometries) {
+    const option = document.createElement('option');
+    option.value = descriptor.id;
+    option.textContent = descriptor.name;
+    geometrySelect.appendChild(option);
+  }
+}
+
 function setGeometry(id: GeometryId) {
-  const geometry = getGeometry(id);
-  core.setGeometry(geometry);
-  const vertexCount = (geometry.positions.length / 4).toFixed(0);
-  const edgeCount = (geometry.indices.length / 2).toFixed(0);
-  statusEl.textContent = `Geometry: ${id} · vertices ${vertexCount} · edges ${edgeCount}`;
+  geometryController.setActiveGeometry(id);
+  const descriptor = geometryController.getDescriptor(id);
+  if (!descriptor) return;
+  const { topology } = descriptor.data;
+  statusEl.textContent = `Geometry: ${descriptor.name} · V ${topology.vertices} · E ${topology.edges} · F ${topology.faces} · C ${topology.cells}`;
 }
 
 geometrySelect.addEventListener('change', (event) => {
@@ -79,9 +894,84 @@ lineWidthSlider.addEventListener('input', (event) => {
   core.setLineWidth(value);
 });
 
+populateGeometryOptions();
+geometrySelect.value = 'tesseract';
 setGeometry('tesseract');
+core.setUniformUploadListener((snapshot, metrics) => {
+  latencyTracker.recordUniform(metrics);
+  const datasetMetrics = datasetExport.getMetrics();
+  if (datasetMetrics.pending >= MAX_PENDING_FRAMES) {
+    return;
+  }
+
+  const frame = core.captureFrame();
+  if (frame.width === 0 || frame.height === 0) {
+    return;
+  }
+
+  const captureTime = performance.now();
+  const captureLatency = Math.max(0, captureTime - snapshot.timestamp);
+  latencyTracker.recordCapture(snapshot.timestamp, captureTime);
+
+  let uniformLatency = metrics.lastUploadLatency;
+  if (metrics.lastSnapshotTimestamp !== snapshot.timestamp) {
+    uniformLatency = Math.max(0, metrics.lastUploadTime - snapshot.timestamp);
+  }
+
+  datasetExport.enqueue({
+    width: frame.width,
+    height: frame.height,
+    pixels: frame.pixels,
+    metadata: {
+      timestamp: snapshot.timestamp,
+      rotationAngles: [snapshot.xy, snapshot.xz, snapshot.yz, snapshot.xw, snapshot.yw, snapshot.zw],
+      confidence: snapshot.confidence,
+      latency: {
+        uniformMs: uniformLatency,
+        uniformTimestamp: metrics.lastUploadTime,
+        captureMs: captureLatency,
+        captureTimestamp: captureTime
+      }
+    }
+  });
+  updateTelemetry();
+});
+
 startSyntheticRotation(autoAngles, timestamp => pushRotationSnapshot(timestamp));
 core.start();
+
+setInterval(() => focusDirector.update(performance.now()), 1000);
+
+setInterval(async () => {
+  const frames = await datasetExport.flush();
+  if (frames.length) {
+    const metrics = datasetExport.getMetrics();
+    const format = metrics.lastFormat ?? 'image/png';
+    frames.forEach(frame => {
+      manifestBuilder.addFrame(frame.metadata, format);
+      pspStream.publish(frame);
+    });
+    persistManifest();
+    updateTelemetry();
+  }
+}, 2000);
+
+function downloadManifest() {
+  persistManifest();
+  const manifest = manifestBuilder.getManifest();
+  const contents = JSON.stringify(manifest, null, 2);
+  const blob = new Blob([contents], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = createManifestDownloadName(manifest);
+  anchor.style.display = 'none';
+  const host = document.body ?? document.documentElement;
+  host?.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+  setTimeout(() => URL.revokeObjectURL(url), 0);
+}
 
 function createRotationControls(
   container: HTMLDivElement,
@@ -149,8 +1039,11 @@ function startSyntheticRotation(autoState: RotationAngles, onUpdate: (timestamp:
     }
 
     onUpdate(now);
-    requestAnimationFrame(tick);
-  };
+  requestAnimationFrame(tick);
+};
 
   requestAnimationFrame(tick);
 }
+
+updateTelemetry();
+setInterval(updateTelemetry, 1000);

--- a/src/pipeline/confidenceTrend.test.ts
+++ b/src/pipeline/confidenceTrend.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  ConfidenceTrend,
+  type ConfidenceTrendAnnotation,
+  type ConfidenceTrendState
+} from './confidenceTrend';
+
+describe('ConfidenceTrend', () => {
+  it('records normalized values, annotations, and trims to max points', () => {
+    const trend = new ConfidenceTrend({ maxPoints: 3 });
+    const annotation: ConfidenceTrendAnnotation = {
+      profileId: 'default-imu',
+      profileName: 'Default',
+      confidenceFloor: 0.72,
+      preprocessors: ['low-pass', 'gravity']
+    };
+
+    trend.record(0.2, 1000, annotation);
+    trend.record(1.5, 2000, { profileId: 'smooth', confidenceFloor: 2 });
+    trend.record(-3, 3000, null);
+    trend.record(0.75, 4000, { profileId: 'default-imu', confidenceFloor: 0.9, preprocessors: ['low-pass'] });
+
+    expect(trend.getValues()).toEqual([1, 0, 0.75]);
+    const samples = trend.getSamples();
+    expect(samples).toHaveLength(3);
+    expect(samples[0]).toMatchObject({
+      value: 1,
+      timestamp: 2000,
+      annotation: { profileId: 'smooth', confidenceFloor: 1 }
+    });
+    expect(samples[1]).toMatchObject({ value: 0, annotation: undefined });
+    expect(samples[2]).toMatchObject({
+      value: 0.75,
+      timestamp: 4000,
+      annotation: { preprocessors: ['low-pass'] }
+    });
+    expect(trend.getUpdatedAt()).toBe(4000);
+  });
+
+  it('ignores non-finite samples', () => {
+    const trend = new ConfidenceTrend();
+    trend.record(Number.NaN);
+    trend.record(Number.POSITIVE_INFINITY);
+
+    expect(trend.isEmpty()).toBe(true);
+    expect(trend.getSamples()).toHaveLength(0);
+    expect(trend.getUpdatedAt()).toBeNull();
+  });
+
+  it('hydrates from legacy value-only state', () => {
+    const past = Date.now() - 10_000;
+    const state: ConfidenceTrendState = {
+      values: [0.1, 0.9, 2, -1, Number.NaN],
+      maxPoints: 3,
+      updatedAt: past
+    };
+
+    const trend = new ConfidenceTrend({ state });
+
+    expect(trend.getValues()).toEqual([0.9, 1, 0]);
+    expect(trend.getUpdatedAt()).toBe(past);
+    for (const sample of trend.getSamples()) {
+      expect(sample.timestamp).toBe(past);
+    }
+  });
+
+  it('hydrates annotated samples from persisted state', () => {
+    const state: ConfidenceTrendState = {
+      values: [0.5, 0.2],
+      samples: [
+        {
+          value: 0.5,
+          timestamp: 500,
+          annotation: {
+            profileId: ' default-imu ',
+            profileName: 'Default',
+            confidenceFloor: 1.4,
+            preprocessors: [' low-pass ', '', '   ']
+          }
+        },
+        {
+          value: 0.2,
+          timestamp: -10,
+          annotation: { profileId: '', confidenceFloor: -1 }
+        }
+      ],
+      maxPoints: 4,
+      updatedAt: 999
+    };
+
+    const trend = new ConfidenceTrend({ state });
+    const samples = trend.getSamples();
+    expect(samples).toEqual([
+      {
+        value: 0.5,
+        timestamp: 500,
+        annotation: {
+          profileId: 'default-imu',
+          profileName: 'Default',
+          confidenceFloor: 1,
+          preprocessors: ['low-pass']
+        }
+      },
+      {
+        value: 0.2,
+        timestamp: undefined,
+        annotation: undefined
+      }
+    ]);
+    expect(trend.getUpdatedAt()).toBe(999);
+  });
+
+  it('serializes back to JSON payload with annotations', () => {
+    const trend = new ConfidenceTrend({ maxPoints: 3 });
+    const now = 1234567890;
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+    trend.record(0.25, now, { profileId: 'default-imu', profileName: 'Default', confidenceFloor: 0.8 });
+    trend.record(0.75, now + 5000);
+    vi.useRealTimers();
+
+    expect(trend.toJSON()).toEqual({
+      values: [0.25, 0.75],
+      samples: [
+        {
+          value: 0.25,
+          timestamp: now,
+          annotation: {
+            profileId: 'default-imu',
+            profileName: 'Default',
+            confidenceFloor: 0.8,
+            preprocessors: []
+          }
+        },
+        {
+          value: 0.75,
+          timestamp: now + 5000,
+          annotation: undefined
+        }
+      ],
+      maxPoints: 3,
+      updatedAt: now + 5000
+    });
+  });
+
+  it('clears stored values and timestamps', () => {
+    const trend = new ConfidenceTrend({ maxPoints: 3 });
+    trend.record(0.6, 2500, { profileId: 'default-imu', confidenceFloor: 0.6 });
+    expect(trend.isEmpty()).toBe(false);
+
+    trend.clear();
+
+    expect(trend.isEmpty()).toBe(true);
+    expect(trend.getSamples()).toHaveLength(0);
+    expect(trend.getUpdatedAt()).toBeNull();
+    expect(trend.toJSON().values).toEqual([]);
+    expect(trend.toJSON().samples).toEqual([]);
+  });
+});

--- a/src/pipeline/confidenceTrend.ts
+++ b/src/pipeline/confidenceTrend.ts
@@ -1,0 +1,257 @@
+export interface ConfidenceTrendAnnotationState {
+  profileId: string;
+  profileName?: string;
+  confidenceFloor: number;
+  preprocessors?: string[];
+}
+
+export interface ConfidenceTrendSampleState {
+  value: number;
+  timestamp?: number;
+  annotation?: ConfidenceTrendAnnotationState | null;
+}
+
+export interface ConfidenceTrendState {
+  values: number[];
+  samples?: ConfidenceTrendSampleState[];
+  maxPoints?: number;
+  updatedAt?: number;
+}
+
+export interface ConfidenceTrendAnnotation {
+  profileId: string;
+  profileName?: string;
+  confidenceFloor: number;
+  preprocessors?: string[];
+}
+
+export interface ConfidenceTrendSample {
+  value: number;
+  timestamp?: number;
+  annotation?: ConfidenceTrendAnnotation;
+}
+
+export interface ConfidenceTrendOptions {
+  maxPoints?: number;
+  state?: ConfidenceTrendState | null;
+}
+
+export const DATASET_CONFIDENCE_TREND_STORAGE_KEY = 'hypercube-core-confidence-trend';
+
+const DEFAULT_MAX_POINTS = 48;
+const MAX_ALLOWED_POINTS = 512;
+const MIN_ALLOWED_POINTS = 1;
+
+type InternalSample = {
+  value: number;
+  timestamp: number | null;
+  annotation?: InternalAnnotation;
+};
+
+type InternalAnnotation = {
+  profileId: string;
+  profileName?: string;
+  confidenceFloor: number;
+  preprocessors: string[];
+};
+
+export class ConfidenceTrend {
+  private samples: InternalSample[];
+  private maxPoints: number;
+  private updatedAt: number;
+
+  constructor(options: ConfidenceTrendOptions = {}) {
+    const state = options.state ?? null;
+    this.maxPoints = sanitizeMaxPoints(options.maxPoints ?? state?.maxPoints);
+
+    this.samples = [];
+    if (state?.samples && Array.isArray(state.samples)) {
+      for (const sample of state.samples) {
+        const sanitized = sanitizeSample(sample);
+        if (sanitized) {
+          this.samples.push(sanitized);
+        }
+      }
+    }
+
+    if (this.samples.length === 0 && state && Array.isArray(state.values)) {
+      const sanitizedValues = state.values
+        .map(normalizeValue)
+        .filter((value): value is number => value !== null);
+      const timestamp = normalizeTimestamp(state.updatedAt);
+      for (const value of sanitizedValues) {
+        this.samples.push({ value, timestamp: timestamp ?? null });
+      }
+    }
+
+    if (this.samples.length > this.maxPoints) {
+      this.samples = this.samples.slice(-this.maxPoints);
+    }
+
+    const hydratedTimestamp = normalizeTimestamp(state?.updatedAt);
+    if (this.samples.length === 0) {
+      this.updatedAt = 0;
+    } else if (typeof hydratedTimestamp === 'number') {
+      this.updatedAt = hydratedTimestamp;
+    } else {
+      const last = this.samples[this.samples.length - 1];
+      if (!last.timestamp) {
+        const now = Date.now();
+        last.timestamp = now;
+        this.updatedAt = now;
+      } else {
+        this.updatedAt = last.timestamp;
+      }
+    }
+  }
+
+  record(
+    value: number,
+    timestamp: number = Date.now(),
+    annotation: ConfidenceTrendAnnotation | null | undefined = undefined
+  ): void {
+    const normalized = normalizeValue(value);
+    if (normalized === null) {
+      return;
+    }
+
+    const validTimestamp = normalizeTimestamp(timestamp) ?? Date.now();
+    const sanitizedAnnotation = sanitizeAnnotation(annotation);
+
+    this.samples.push({ value: normalized, timestamp: validTimestamp, annotation: sanitizedAnnotation });
+    if (this.samples.length > this.maxPoints) {
+      this.samples.splice(0, this.samples.length - this.maxPoints);
+    }
+
+    this.updatedAt = validTimestamp;
+  }
+
+  clear(): void {
+    this.samples = [];
+    this.updatedAt = 0;
+  }
+
+  getValues(): readonly number[] {
+    return this.samples.map(sample => sample.value);
+  }
+
+  getSamples(): ReadonlyArray<ConfidenceTrendSample> {
+    return this.samples.map(sample => ({
+      value: sample.value,
+      timestamp: sample.timestamp ?? undefined,
+      annotation: sample.annotation
+        ? { ...sample.annotation }
+        : undefined
+    }));
+  }
+
+  isEmpty(): boolean {
+    return this.samples.length === 0;
+  }
+
+  getUpdatedAt(): number | null {
+    if (this.samples.length === 0) {
+      return null;
+    }
+    return this.updatedAt || null;
+  }
+
+  toJSON(): ConfidenceTrendState {
+    const samples = this.samples.map(sample => ({
+      value: sample.value,
+      timestamp: sample.timestamp ?? undefined,
+      annotation: sample.annotation ? { ...sample.annotation } : undefined
+    }));
+
+    return {
+      values: samples.map(sample => sample.value),
+      samples,
+      maxPoints: this.maxPoints,
+      updatedAt: this.getUpdatedAt() ?? 0
+    };
+  }
+}
+
+function sanitizeMaxPoints(value: unknown): number {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric) || numeric <= 0) {
+    return DEFAULT_MAX_POINTS;
+  }
+  const bounded = Math.min(Math.max(Math.floor(numeric), MIN_ALLOWED_POINTS), MAX_ALLOWED_POINTS);
+  return bounded;
+}
+
+function normalizeValue(value: unknown): number | null {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) {
+    return null;
+  }
+  if (numeric <= 0) {
+    return 0;
+  }
+  if (numeric >= 1) {
+    return 1;
+  }
+  return numeric;
+}
+
+function normalizeTimestamp(value: unknown): number | null {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric) || numeric <= 0) {
+    return null;
+  }
+  return numeric;
+}
+
+function sanitizeSample(sample: ConfidenceTrendSampleState | null | undefined): InternalSample | null {
+  if (!sample || typeof sample !== 'object') {
+    return null;
+  }
+
+  const normalizedValue = normalizeValue(sample.value);
+  if (normalizedValue === null) {
+    return null;
+  }
+
+  const timestamp = normalizeTimestamp(sample.timestamp);
+  const annotation = sanitizeAnnotation(sample.annotation ?? undefined);
+
+  return {
+    value: normalizedValue,
+    timestamp: timestamp ?? null,
+    annotation
+  };
+}
+
+function sanitizeAnnotation(
+  annotation: ConfidenceTrendAnnotation | ConfidenceTrendAnnotationState | null | undefined
+): InternalAnnotation | undefined {
+  if (!annotation || typeof annotation !== 'object') {
+    return undefined;
+  }
+
+  const profileId = typeof annotation.profileId === 'string' ? annotation.profileId.trim() : '';
+  if (!profileId) {
+    return undefined;
+  }
+
+  const profileName = typeof annotation.profileName === 'string' ? annotation.profileName : undefined;
+  const floorNumeric = Number(annotation.confidenceFloor);
+  const confidenceFloor = Number.isFinite(floorNumeric)
+    ? Math.min(Math.max(floorNumeric, 0), 1)
+    : 0;
+
+  let preprocessors: string[] = [];
+  if (Array.isArray(annotation.preprocessors)) {
+    preprocessors = annotation.preprocessors
+      .map(entry => (typeof entry === 'string' ? entry.trim() : String(entry)))
+      .filter(entry => entry.length > 0);
+  }
+
+  return {
+    profileId,
+    profileName,
+    confidenceFloor,
+    preprocessors
+  };
+}

--- a/src/pipeline/contextScheduler.test.ts
+++ b/src/pipeline/contextScheduler.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { ContextScheduler } from './contextScheduler';
+
+describe('ContextScheduler', () => {
+  it('caps contexts and memory budgets', () => {
+    const scheduler = new ContextScheduler();
+    for (let i = 0; i < 25; i++) {
+      scheduler.registerContext({
+        id: `ctx-${i}`,
+        priority: i < 5 ? 'critical' : 'background',
+        memoryMB: 128
+      });
+    }
+    const snapshot = scheduler.getSnapshot();
+    expect(snapshot.active.length).toBeLessThanOrEqual(20);
+    expect(snapshot.rejected.length).toBeGreaterThan(0);
+    expect(snapshot.totalMemory).toBeLessThanOrEqual(4096);
+  });
+});

--- a/src/pipeline/contextScheduler.ts
+++ b/src/pipeline/contextScheduler.ts
@@ -1,0 +1,48 @@
+export type ContextPriority = 'critical' | 'interactive' | 'background';
+
+export interface ContextDescriptor {
+  id: string;
+  priority: ContextPriority;
+  memoryMB: number;
+}
+
+export interface SchedulerSnapshot {
+  active: ContextDescriptor[];
+  totalMemory: number;
+  rejected: ContextDescriptor[];
+}
+
+const PRIORITY_ORDER: ContextPriority[] = ['critical', 'interactive', 'background'];
+const MAX_CONTEXTS = 20;
+const MAX_MEMORY_MB = 4096;
+
+export class ContextScheduler {
+  private readonly contexts: ContextDescriptor[] = [];
+  private readonly rejected: ContextDescriptor[] = [];
+
+  registerContext(descriptor: ContextDescriptor) {
+    this.contexts.push(descriptor);
+    this.contexts.sort((a, b) => PRIORITY_ORDER.indexOf(a.priority) - PRIORITY_ORDER.indexOf(b.priority));
+    this.enforceBudgets();
+  }
+
+  getSnapshot(): SchedulerSnapshot {
+    return {
+      active: this.contexts.slice(),
+      totalMemory: this.contexts.reduce((sum, context) => sum + context.memoryMB, 0),
+      rejected: this.rejected.slice()
+    };
+  }
+
+  private enforceBudgets() {
+    while (this.contexts.length > MAX_CONTEXTS || this.totalMemory() > MAX_MEMORY_MB) {
+      const removed = this.contexts.pop();
+      if (!removed) break;
+      this.rejected.push(removed);
+    }
+  }
+
+  private totalMemory(): number {
+    return this.contexts.reduce((sum, context) => sum + context.memoryMB, 0);
+  }
+}

--- a/src/pipeline/datasetExport.test.ts
+++ b/src/pipeline/datasetExport.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from 'vitest';
+import { DatasetExportService } from './datasetExport';
+import { encodeFrameToBlob } from './frameEncoding';
+
+interface WorkerRequest {
+  id: number;
+  format: 'image/png';
+  frame: {
+    width: number;
+    height: number;
+    pixels: Uint8ClampedArray;
+    metadata: {
+      timestamp: number;
+      rotationAngles: [number, number, number, number, number, number];
+      confidence?: number;
+    };
+  };
+}
+
+interface WorkerResponse {
+  id: number;
+  success: boolean;
+  blob?: Blob;
+  error?: string;
+}
+
+class FakeWorker extends EventTarget {
+  onmessage: ((this: Worker, ev: MessageEvent<WorkerResponse>) => unknown) | null = null;
+  onerror: ((this: AbstractWorker, ev: ErrorEvent) => any) | null = null;
+  onmessageerror: ((this: Worker, ev: MessageEvent) => unknown) | null = null;
+
+  constructor(private readonly handler: (data: WorkerRequest) => Promise<WorkerResponse>) {
+    super();
+  }
+
+  postMessage(message: WorkerRequest, _transfer?: Transferable[] | StructuredSerializeOptions): void {
+    void this.handler(message)
+      .then(response => {
+        this.onmessage?.call(this, { data: response } as MessageEvent<WorkerResponse>);
+      })
+      .catch(error => {
+        this.onerror?.call(this, new ErrorEvent('error', { message: (error as Error).message }));
+      });
+  }
+
+  terminate(): void {}
+}
+
+describe('DatasetExportService', () => {
+  it('encodes frames via JSON fallback when OffscreenCanvas is unavailable', async () => {
+    const service = new DatasetExportService();
+    expect(service.getMetrics()).toMatchObject({ pending: 0, totalEncoded: 0, lastFormat: null });
+    service.enqueue({
+      width: 2,
+      height: 2,
+      pixels: new Uint8ClampedArray([255, 0, 0, 255, 0, 255, 0, 255, 0, 0, 255, 255, 255, 255, 255, 255]),
+      metadata: {
+        timestamp: 1,
+        rotationAngles: [0, 0, 0, 0, 0, 0],
+        confidence: 0.83,
+        latency: {
+          uniformMs: 2,
+          uniformTimestamp: 3,
+          captureMs: 4,
+          captureTimestamp: 5
+        }
+      }
+    });
+    expect(service.getMetrics().pending).toBe(1);
+    const [frame] = await service.flush();
+    expect(frame.metadata.timestamp).toBe(1);
+    expect(frame.metadata.confidence).toBeCloseTo(0.83, 5);
+    const text = await frame.blob.text();
+    expect(text).toContain('checksum');
+    const latency = frame.metadata.latency;
+    expect(latency).toBeDefined();
+    expect(latency?.uniformMs).toBe(2);
+    expect(latency?.captureMs).toBe(4);
+    expect(latency?.captureTimestamp).toBe(5);
+    expect(latency?.encodeMs).toBeGreaterThanOrEqual(0);
+    expect(latency?.encodeCompletedTimestamp).toBeGreaterThanOrEqual(latency!.captureTimestamp);
+    expect(latency?.totalMs).toBeCloseTo((latency?.encodeCompletedTimestamp ?? 0) - frame.metadata.timestamp, 5);
+    const metrics = service.getMetrics();
+    expect(metrics.pending).toBe(0);
+    expect(metrics.totalEncoded).toBe(1);
+    expect(metrics.lastFormat).toBe('image/png');
+    expect(metrics.lastLatencyMs).toBeGreaterThanOrEqual(0);
+    expect(metrics.averageLatencyMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it('dispatches frames through a worker when provided', async () => {
+    const workerFactory = () =>
+      new FakeWorker(async (message: WorkerRequest) => {
+        const blob = await encodeFrameToBlob(message.frame, message.format);
+        return { id: message.id, success: true, blob } satisfies WorkerResponse;
+      }) as unknown as Worker;
+
+    let samples: number[] = [];
+    const service = new DatasetExportService({
+      workerFactory,
+      onLatencySample: latency => samples.push(latency)
+    });
+
+    service.enqueue({
+      width: 2,
+      height: 2,
+      pixels: new Uint8ClampedArray([0, 0, 0, 255, 255, 255, 255, 255, 64, 64, 64, 255, 128, 128, 128, 255]),
+      metadata: {
+        timestamp: 2,
+        rotationAngles: [0, 0, 0, 0, 0, 0],
+        confidence: 0.75,
+        latency: {
+          uniformMs: 1.5,
+          captureMs: 3,
+          captureTimestamp: 10
+        }
+      }
+    });
+
+    const frames = await service.flush('image/png');
+    expect(frames).toHaveLength(1);
+    const latency = frames[0].metadata.latency;
+    expect(frames[0].metadata.confidence).toBeCloseTo(0.75, 5);
+    expect(latency?.encodeMs).toBeGreaterThanOrEqual(0);
+    expect(latency?.totalMs).toBeGreaterThan(0);
+    expect(samples.length).toBeGreaterThan(0);
+    expect(service.getMetrics().totalEncoded).toBe(1);
+    expect(service.getMetrics().lastLatencyMs).toBeGreaterThan(0);
+  });
+
+  it('annotates latency when metadata does not provide an envelope', async () => {
+    const service = new DatasetExportService();
+    service.enqueue({
+      width: 1,
+      height: 1,
+      pixels: new Uint8ClampedArray([0, 0, 0, 255]),
+      metadata: { timestamp: 4, rotationAngles: [0, 0, 0, 0, 0, 0] }
+    });
+
+    const [frame] = await service.flush();
+    expect(frame.metadata.latency).toBeDefined();
+    expect(frame.metadata.latency?.captureTimestamp).toBeGreaterThan(0);
+    expect(frame.metadata.latency?.totalMs).toBeGreaterThanOrEqual(0);
+  });
+});

--- a/src/pipeline/datasetExport.ts
+++ b/src/pipeline/datasetExport.ts
@@ -1,0 +1,206 @@
+import type {
+  FrameFormat,
+  FramePayload,
+  EncodedFrame,
+  FrameMetadata,
+  PipelineLatencyEnvelope
+} from './datasetTypes';
+import { encodeFrameToBlob } from './frameEncoding';
+
+export interface DatasetExportMetrics {
+  pending: number;
+  totalEncoded: number;
+  lastFormat: FrameFormat | null;
+  lastLatencyMs: number;
+  averageLatencyMs: number;
+}
+
+export interface DatasetExportOptions {
+  workerFactory?: () => Worker;
+  sampleWindow?: number;
+  onLatencySample?: (latencyMs: number) => void;
+}
+
+interface WorkerRequest {
+  id: number;
+  format: FrameFormat;
+  frame: FramePayload;
+}
+
+interface WorkerSuccess {
+  id: number;
+  success: true;
+  blob: Blob;
+}
+
+interface WorkerFailure {
+  id: number;
+  success: false;
+  error: string;
+}
+
+type WorkerResponse = WorkerSuccess | WorkerFailure;
+
+interface PendingJob {
+  resolve: (frame: EncodedFrame) => void;
+  reject: (error: Error) => void;
+  metadata: FrameMetadata;
+  start: number;
+}
+
+export class DatasetExportService {
+  private readonly queue: FramePayload[] = [];
+  private readonly latencies: number[] = [];
+  private readonly maxSamples: number;
+  private latencySum = 0;
+  private totalEncoded = 0;
+  private lastFormat: FrameFormat | null = null;
+  private lastLatency = 0;
+  private worker: Worker | null = null;
+  private jobId = 0;
+  private readonly pendingJobs = new Map<number, PendingJob>();
+
+  constructor(private readonly options: DatasetExportOptions = {}) {
+    this.maxSamples = options.sampleWindow ?? 32;
+    const worker = this.createWorker();
+    if (worker) {
+      this.worker = worker;
+      worker.onmessage = event => this.handleWorkerMessage(event.data as WorkerResponse);
+      worker.onerror = event => {
+        console.error('Dataset worker error', event);
+      };
+    }
+  }
+
+  enqueue(frame: FramePayload) {
+    this.queue.push(frame);
+  }
+
+  async flush(format: FrameFormat = 'image/png'): Promise<EncodedFrame[]> {
+    const frames = this.queue.splice(0);
+    if (frames.length === 0) {
+      return [];
+    }
+
+    const results = this.worker
+      ? await this.encodeWithWorker(frames, format)
+      : await this.encodeSequential(frames, format);
+
+    if (results.length > 0) {
+      this.totalEncoded += results.length;
+      this.lastFormat = format;
+    }
+    return results;
+  }
+
+  getMetrics(): DatasetExportMetrics {
+    return {
+      pending: this.queue.length,
+      totalEncoded: this.totalEncoded,
+      lastFormat: this.lastFormat,
+      lastLatencyMs: this.lastLatency,
+      averageLatencyMs: this.latencies.length ? this.latencySum / this.latencies.length : 0
+    };
+  }
+
+  private async encodeSequential(frames: FramePayload[], format: FrameFormat): Promise<EncodedFrame[]> {
+    const results: EncodedFrame[] = [];
+    for (const frame of frames) {
+      const start = performance.now();
+      const blob = await encodeFrameToBlob(frame, format);
+      const latency = performance.now() - start;
+      this.recordLatency(latency);
+      results.push({ blob, metadata: this.withEncodeLatency(frame.metadata, start, latency) });
+    }
+    return results;
+  }
+
+  private encodeWithWorker(frames: FramePayload[], format: FrameFormat): Promise<EncodedFrame[]> {
+    return Promise.all(frames.map(frame => this.enqueueJob(frame, format)));
+  }
+
+  private enqueueJob(frame: FramePayload, format: FrameFormat): Promise<EncodedFrame> {
+    if (!this.worker) {
+      throw new Error('Worker unavailable');
+    }
+    const id = ++this.jobId;
+    const start = performance.now();
+    return new Promise<EncodedFrame>((resolve, reject) => {
+      this.pendingJobs.set(id, { resolve, reject, metadata: frame.metadata, start });
+      try {
+        this.worker!.postMessage({ id, format, frame } satisfies WorkerRequest, [frame.pixels.buffer]);
+      } catch (error) {
+        this.pendingJobs.delete(id);
+        reject(error as Error);
+      }
+    });
+  }
+
+  private handleWorkerMessage(message: WorkerResponse) {
+    const job = this.pendingJobs.get(message.id);
+    if (!job) {
+      return;
+    }
+    this.pendingJobs.delete(message.id);
+    if (!message.success) {
+      job.reject(new Error(message.error));
+      return;
+    }
+    const latency = performance.now() - job.start;
+    this.recordLatency(latency);
+    job.resolve({ blob: message.blob, metadata: this.withEncodeLatency(job.metadata, job.start, latency) });
+  }
+
+  private recordLatency(latency: number) {
+    if (!Number.isFinite(latency) || latency < 0) {
+      return;
+    }
+    this.lastLatency = latency;
+    this.latencies.push(latency);
+    this.latencySum += latency;
+    if (this.latencies.length > this.maxSamples) {
+      const removed = this.latencies.shift();
+      if (removed !== undefined) {
+        this.latencySum -= removed;
+      }
+    }
+    if (this.options.onLatencySample) {
+      this.options.onLatencySample(latency);
+    }
+  }
+
+  private withEncodeLatency(metadata: FrameMetadata, start: number, encodeLatency: number): FrameMetadata {
+    const encodeCompletedTimestamp = start + encodeLatency;
+    const latency: PipelineLatencyEnvelope = {
+      uniformMs: metadata.latency?.uniformMs ?? 0,
+      uniformTimestamp: metadata.latency?.uniformTimestamp,
+      captureMs: metadata.latency?.captureMs ?? 0,
+      captureTimestamp: metadata.latency?.captureTimestamp ?? start,
+      encodeMs: encodeLatency,
+      encodeCompletedTimestamp,
+      totalMs: encodeCompletedTimestamp - metadata.timestamp
+    };
+
+    return {
+      ...metadata,
+      latency
+    };
+  }
+
+  private createWorker(): Worker | null {
+    if (this.options.workerFactory) {
+      return this.options.workerFactory();
+    }
+    if (typeof Worker === 'undefined') {
+      return null;
+    }
+    try {
+      return new Worker(new URL('./datasetWorker.ts', import.meta.url), { type: 'module' });
+    } catch (error) {
+      console.warn('Failed to initialise dataset export worker', error);
+      return null;
+    }
+  }
+}
+
+export type { EncodedFrame, FrameMetadata, PipelineLatencyEnvelope } from './datasetTypes';

--- a/src/pipeline/datasetManifest.test.ts
+++ b/src/pipeline/datasetManifest.test.ts
@@ -1,0 +1,308 @@
+import { describe, expect, it, vi } from 'vitest';
+import { DatasetManifestBuilder, createManifestDownloadName, type DatasetTelemetryLog } from './datasetManifest';
+import type { ConfidenceTrendState } from './confidenceTrend';
+
+const sampleAngles: [number, number, number, number, number, number] = [0, 0.1, 0.2, 0.3, 0.4, 0.5];
+
+describe('DatasetManifestBuilder', () => {
+  it('generates deterministic asset names and retains latency envelopes', () => {
+    const builder = new DatasetManifestBuilder({ sessionId: 'test-session', prefix: 'sample' });
+    builder.addFrame(
+      {
+        timestamp: 123,
+        rotationAngles: sampleAngles,
+        confidence: 0.72,
+        latency: {
+          uniformMs: 2,
+          captureMs: 3,
+          captureTimestamp: 10,
+          encodeMs: 5,
+          totalMs: 10
+        }
+      },
+      'image/png'
+    );
+
+    const manifest = builder.getManifest();
+    expect(manifest.id).toBe('test-session');
+    expect(manifest.frames).toHaveLength(1);
+    expect(manifest.frames[0].assetName).toBe('sample-000001.png');
+    expect(manifest.frames[0].confidence).toBeCloseTo(0.72, 5);
+    expect(manifest.frames[0].latency?.totalMs).toBe(10);
+    expect(manifest.stats.totalFrames).toBe(1);
+    expect(manifest.stats.p95TotalLatencyMs).toBe(10);
+    expect(manifest.stats.confidenceHistogram.totalSamples).toBe(1);
+    const histogram = manifest.stats.confidenceHistogram.counts;
+    expect(histogram.reduce((sum, value) => sum + value, 0)).toBe(1);
+  });
+
+  it('rehydrates from an existing manifest and continues numbering', () => {
+    const initial = new DatasetManifestBuilder({ prefix: 'frame' });
+    initial.addFrame(
+      {
+        timestamp: 1,
+        rotationAngles: sampleAngles,
+        latency: { uniformMs: 1, captureMs: 2, captureTimestamp: 5, totalMs: 5 }
+      },
+      'image/png'
+    );
+
+    const resumed = new DatasetManifestBuilder({ hydrateFrom: initial.getManifest() });
+    const added = resumed.addFrame(
+      {
+        timestamp: 2,
+        rotationAngles: sampleAngles,
+        confidence: 0.91,
+        latency: { uniformMs: 2, captureMs: 4, captureTimestamp: 8, encodeMs: 4 }
+      },
+      'image/webp'
+    );
+
+    expect(added.assetName).toBe('frame-000002.webp');
+    const manifest = resumed.getManifest();
+    expect(manifest.frames).toHaveLength(2);
+    expect(manifest.stats.totalFrames).toBe(2);
+    expect(manifest.stats.p95TotalLatencyMs).toBeGreaterThanOrEqual(manifest.stats.averageTotalLatencyMs);
+    expect(manifest.stats.maxTotalLatencyMs).toBeGreaterThan(0);
+    expect(manifest.stats.confidenceHistogram.totalSamples).toBeGreaterThanOrEqual(1);
+  });
+
+  it('calculates aggregate statistics even when total latency is omitted', () => {
+    const builder = new DatasetManifestBuilder({ prefix: 'capture' });
+    builder.addFrame(
+      {
+        timestamp: 3,
+        rotationAngles: sampleAngles,
+        confidence: 0.42,
+        latency: {
+          uniformMs: 3,
+          captureMs: 7,
+          captureTimestamp: 11
+        }
+      },
+      'image/png'
+    );
+
+    builder.addFrame(
+      {
+        timestamp: 4,
+        rotationAngles: sampleAngles,
+        confidence: 0.96,
+        latency: {
+          uniformMs: 4,
+          captureMs: 6,
+          captureTimestamp: 12,
+          encodeMs: 5
+        }
+      },
+      'image/png'
+    );
+
+    const manifest = builder.getManifest();
+    expect(manifest.stats.totalFrames).toBe(2);
+    expect(manifest.stats.averageTotalLatencyMs).toBeGreaterThan(0);
+    expect(manifest.stats.p95TotalLatencyMs).toBeGreaterThan(0);
+    expect(manifest.stats.confidenceHistogram.totalSamples).toBe(2);
+  });
+
+  it('creates sanitized manifest download names with timestamps', () => {
+    vi.useFakeTimers();
+    const now = new Date('2024-04-05T12:34:56.789Z');
+    vi.setSystemTime(now);
+
+    const builder = new DatasetManifestBuilder({ sessionId: 'Session 42', prefix: 'frame' });
+    const manifest = builder.getManifest();
+
+    const filename = createManifestDownloadName(manifest);
+    expect(filename).toBe('session-42-2024-04-05T12-34-56-789Z.manifest.json');
+
+    vi.useRealTimers();
+  });
+
+  it('records and rehydrates parserator ingestion metadata', () => {
+    const builder = new DatasetManifestBuilder({ sessionId: 'ingestion-session' });
+    builder.updateIngestionConfig({
+      profileId: 'default-imu',
+      profileName: 'Default IMU',
+      confidenceFloor: 0.65,
+      preprocessors: ['low-pass', 'gravity']
+    });
+
+    const manifest = builder.getManifest();
+    expect(manifest.ingestion?.profileId).toBe('default-imu');
+    expect(manifest.ingestion?.preprocessors).toEqual(['low-pass', 'gravity']);
+    expect(manifest.ingestion?.updatedAt).toBeGreaterThan(0);
+
+    const rehydrated = new DatasetManifestBuilder({ hydrateFrom: manifest });
+    expect(rehydrated.getManifest().ingestion?.profileId).toBe('default-imu');
+  });
+
+  it('rehydrates confidence histograms and tracks new samples', () => {
+    const builder = new DatasetManifestBuilder({ sessionId: 'confidence-session' });
+    builder.addFrame(
+      { timestamp: 10, rotationAngles: sampleAngles, confidence: 0.95 },
+      'image/png'
+    );
+    builder.addFrame(
+      { timestamp: 11, rotationAngles: sampleAngles, confidence: 0.45 },
+      'image/png'
+    );
+
+    const manifest = builder.getManifest();
+    const rehydrated = new DatasetManifestBuilder({ hydrateFrom: manifest });
+    const before = rehydrated.getManifest().stats.confidenceHistogram;
+    expect(before.totalSamples).toBe(2);
+
+    rehydrated.addFrame(
+      { timestamp: 12, rotationAngles: sampleAngles, confidence: 0.88 },
+      'image/png'
+    );
+
+    const after = rehydrated.getManifest().stats.confidenceHistogram;
+    expect(after.totalSamples).toBe(3);
+    expect(after.counts.reduce((sum, value) => sum + value, 0)).toBe(3);
+  });
+
+  it('persists telemetry events and rehydrates them from storage', () => {
+    const builder = new DatasetManifestBuilder({ sessionId: 'telemetry-session' });
+    const snapshot: DatasetTelemetryLog = {
+      capacity: 5,
+      updatedAt: 5000,
+      events: [
+        {
+          id: 1,
+          category: 'parserator',
+          message: 'Profile selected',
+          timestamp: 1000,
+          metadata: { profileId: 'default' }
+        },
+        {
+          id: 2,
+          category: 'system',
+          message: 'Hydrated',
+          timestamp: 2000
+        }
+      ]
+    };
+
+    builder.updateTelemetry(snapshot);
+
+    const manifest = builder.getManifest();
+    expect(manifest.telemetry?.capacity).toBe(5);
+    expect(manifest.telemetry?.events).toHaveLength(2);
+    expect(manifest.telemetry?.events[0].metadata).toEqual({ profileId: 'default' });
+
+    const mutated = manifest.telemetry!;
+    if (mutated.events[0].metadata) {
+      mutated.events[0].metadata.profileId = 'mutated';
+    }
+
+    const manifestAfterMutation = builder.getManifest();
+    expect(manifestAfterMutation.telemetry?.events[0].metadata).toEqual({ profileId: 'default' });
+
+    const resumed = new DatasetManifestBuilder({ hydrateFrom: manifest });
+    const resumedTelemetry = resumed.getManifest().telemetry;
+    expect(resumedTelemetry?.events).toHaveLength(2);
+    expect(resumedTelemetry?.events[1].message).toBe('Hydrated');
+
+    resumed.updateTelemetry({
+      capacity: 1,
+      updatedAt: 9000,
+      events: [
+        { id: 10, category: 'parserator', message: 'Trimmed out', timestamp: 3000 },
+        { id: 11, category: 'parserator', message: 'Latest', timestamp: 4000 }
+      ]
+    });
+
+    const trimmed = resumed.getManifest().telemetry;
+    expect(trimmed?.capacity).toBe(1);
+    expect(trimmed?.events).toHaveLength(1);
+    expect(trimmed?.events[0].id).toBe(11);
+  });
+
+  it('stores confidence trend samples and rehydrates them', () => {
+    const builder = new DatasetManifestBuilder({ sessionId: 'trend-session' });
+    const trendState: ConfidenceTrendState = {
+      values: [0.2, 1.4, -0.5],
+      samples: [
+        {
+          value: 0.2,
+          timestamp: 1000,
+          annotation: {
+            profileId: 'default-imu',
+            profileName: 'Default IMU',
+            confidenceFloor: 0.6,
+            preprocessors: ['low-pass']
+          }
+        },
+        {
+          value: 1.4,
+          timestamp: 1100,
+          annotation: {
+            profileId: 'smooth-orbit',
+            confidenceFloor: 0.55,
+            preprocessors: []
+          }
+        },
+        {
+          value: -0.5,
+          timestamp: 1200,
+          annotation: {
+            profileId: 'high-gain-imu',
+            profileName: 'High Gain',
+            confidenceFloor: 0.3
+          }
+        }
+      ],
+      maxPoints: 60,
+      updatedAt: 1234
+    };
+
+    builder.updateConfidenceTrend(trendState);
+
+    const manifest = builder.getManifest();
+    expect(manifest.confidenceTrend).toBeDefined();
+    expect(manifest.confidenceTrend?.values).toEqual([0.2, 1, 0]);
+    expect(manifest.confidenceTrend?.samples).toEqual([
+      {
+        value: 0.2,
+        timestamp: 1000,
+        annotation: {
+          profileId: 'default-imu',
+          profileName: 'Default IMU',
+          confidenceFloor: 0.6,
+          preprocessors: ['low-pass']
+        }
+      },
+      {
+        value: 1,
+        timestamp: 1100,
+        annotation: {
+          profileId: 'smooth-orbit',
+          confidenceFloor: 0.55,
+          preprocessors: []
+        }
+      },
+      {
+        value: 0,
+        timestamp: 1200,
+        annotation: {
+          profileId: 'high-gain-imu',
+          profileName: 'High Gain',
+          confidenceFloor: 0.3,
+          preprocessors: []
+        }
+      }
+    ]);
+    expect(manifest.confidenceTrend?.maxPoints).toBe(60);
+    expect(manifest.confidenceTrend?.updatedAt).toBe(1234);
+
+    const rehydrated = new DatasetManifestBuilder({ hydrateFrom: manifest });
+    const rehydratedTrend = rehydrated.getManifest().confidenceTrend;
+    expect(rehydratedTrend?.values).toEqual([0.2, 1, 0]);
+    expect(rehydratedTrend?.samples).toEqual(manifest.confidenceTrend?.samples);
+
+    builder.updateConfidenceTrend({ values: [], samples: [], maxPoints: 10, updatedAt: 0 });
+    expect(builder.getManifest().confidenceTrend).toBeUndefined();
+  });
+});

--- a/src/pipeline/datasetManifest.ts
+++ b/src/pipeline/datasetManifest.ts
@@ -1,0 +1,477 @@
+import { ConfidenceTrend } from './confidenceTrend';
+import type { ConfidenceTrendState } from './confidenceTrend';
+import type { FrameFormat, FrameMetadata, PipelineLatencyEnvelope } from './datasetTypes';
+import type { TelemetryLogSnapshot, TelemetryEvent, TelemetryCategory } from './telemetryLoom';
+
+export interface DatasetManifestFrame {
+  assetName: string;
+  format: FrameFormat;
+  timestamp: number;
+  rotationAngles: [number, number, number, number, number, number];
+  confidence?: number;
+  latency?: PipelineLatencyEnvelope;
+}
+
+export interface DatasetManifestStatistics {
+  totalFrames: number;
+  averageTotalLatencyMs: number;
+  p95TotalLatencyMs: number;
+  minTotalLatencyMs: number;
+  maxTotalLatencyMs: number;
+  lastUpdated: number;
+  confidenceHistogram: ConfidenceHistogram;
+}
+
+export interface ConfidenceHistogram {
+  bucketSize: number;
+  counts: number[];
+  totalSamples: number;
+}
+
+export interface DatasetIngestionConfig {
+  profileId: string;
+  profileName?: string;
+  confidenceFloor: number;
+  preprocessors: string[];
+  updatedAt: number;
+}
+
+export interface DatasetManifest {
+  id: string;
+  createdAt: number;
+  prefix: string;
+  frames: DatasetManifestFrame[];
+  stats: DatasetManifestStatistics;
+  ingestion?: DatasetIngestionConfig;
+  telemetry?: DatasetTelemetryLog;
+  confidenceTrend?: ConfidenceTrendState;
+}
+
+export interface DatasetTelemetryLog extends TelemetryLogSnapshot {}
+
+export interface DatasetManifestBuilderOptions {
+  sessionId?: string;
+  prefix?: string;
+  startIndex?: number;
+  hydrateFrom?: DatasetManifest;
+}
+
+export const DATASET_MANIFEST_STORAGE_KEY = 'hypercube-core-dataset-manifest';
+
+const DEFAULT_PREFIX = 'frame';
+const DEFAULT_SESSION_PREFIX = 'dataset';
+const DEFAULT_CONFIDENCE_BUCKET_SIZE = 0.1;
+
+export function createManifestDownloadName(manifest: DatasetManifest): string {
+  const baseId = manifest.id.trim() || DEFAULT_SESSION_PREFIX;
+  const normalizedId =
+    baseId
+      .toLowerCase()
+      .replace(/[^a-z0-9-_]+/g, '-')
+      .replace(/-+/g, '-')
+      .replace(/^-|-$/g, '') || DEFAULT_SESSION_PREFIX;
+  const timestampSource = manifest.stats.lastUpdated || manifest.createdAt || Date.now();
+  const timestamp = new Date(timestampSource).toISOString().replace(/[:.]/g, '-');
+  return `${normalizedId}-${timestamp}.manifest.json`;
+}
+
+export class DatasetManifestBuilder {
+  private readonly prefix: string;
+  private manifest: DatasetManifest;
+  private nextIndex: number;
+  private readonly totalLatencies: number[] = [];
+  private confidenceHistogram: ConfidenceHistogram;
+  private confidenceTrend?: ConfidenceTrendState;
+
+  constructor(options: DatasetManifestBuilderOptions = {}) {
+    this.prefix = options.prefix ?? options.hydrateFrom?.prefix ?? DEFAULT_PREFIX;
+
+    if (options.hydrateFrom) {
+      this.manifest = cloneManifest(options.hydrateFrom);
+      this.nextIndex = this.manifest.frames.length + (options.startIndex ?? 0);
+      if (this.manifest.telemetry) {
+        this.manifest.telemetry = normalizeTelemetryLog(this.manifest.telemetry);
+      }
+      const existingHistogram = this.manifest.stats.confidenceHistogram;
+      if (existingHistogram) {
+        this.confidenceHistogram = cloneHistogram(existingHistogram);
+      } else {
+        this.confidenceHistogram = createEmptyHistogram();
+      }
+      const hydratedTrend = normalizeConfidenceTrendState(this.manifest.confidenceTrend);
+      if (hydratedTrend) {
+        this.confidenceTrend = hydratedTrend;
+      } else {
+        delete this.manifest.confidenceTrend;
+      }
+      for (const frame of this.manifest.frames) {
+        const latency = computeTotalLatency(frame.latency);
+        if (latency !== null) {
+          this.totalLatencies.push(latency);
+        }
+        if (!existingHistogram && typeof frame.confidence === 'number') {
+          this.recordConfidence(frame.confidence);
+        }
+      }
+      this.updateStatistics();
+      this.syncConfidenceTrend();
+    } else {
+      const sessionId = options.sessionId ?? createSessionId();
+      this.confidenceHistogram = createEmptyHistogram();
+      this.manifest = {
+        id: sessionId,
+        createdAt: Date.now(),
+        prefix: this.prefix,
+        frames: [],
+        stats: createEmptyStats(this.confidenceHistogram)
+      };
+      this.nextIndex = options.startIndex ?? 0;
+    }
+  }
+
+  addFrame(metadata: FrameMetadata, format: FrameFormat): DatasetManifestFrame {
+    const assetName = this.createAssetName(format);
+    const frame: DatasetManifestFrame = {
+      assetName,
+      format,
+      timestamp: metadata.timestamp,
+      rotationAngles: metadata.rotationAngles,
+      confidence: normalizeConfidence(metadata.confidence) ?? undefined,
+      latency: metadata.latency
+    };
+
+    this.manifest.frames.push(frame);
+    this.nextIndex += 1;
+
+    const latency = computeTotalLatency(metadata.latency);
+    if (latency !== null) {
+      this.totalLatencies.push(latency);
+    }
+
+    if (typeof frame.confidence === 'number') {
+      this.recordConfidence(frame.confidence);
+    }
+
+    this.updateStatistics();
+
+    return frame;
+  }
+
+  getManifest(): DatasetManifest {
+    this.syncConfidenceTrend();
+    return cloneManifest(this.manifest);
+  }
+
+  updateIngestionConfig(config: Omit<DatasetIngestionConfig, 'updatedAt'>): void {
+    this.manifest.ingestion = {
+      ...config,
+      updatedAt: Date.now()
+    };
+  }
+
+  updateTelemetry(log: DatasetTelemetryLog | null | undefined): void {
+    if (!log) {
+      delete this.manifest.telemetry;
+      return;
+    }
+
+    this.manifest.telemetry = normalizeTelemetryLog(log);
+  }
+
+  updateConfidenceTrend(state: ConfidenceTrendState | null | undefined): void {
+    if (!state) {
+      this.confidenceTrend = undefined;
+      delete this.manifest.confidenceTrend;
+      return;
+    }
+
+    const normalized = normalizeConfidenceTrendState(state);
+    if (!normalized || normalized.values.length === 0) {
+      this.confidenceTrend = undefined;
+      delete this.manifest.confidenceTrend;
+      return;
+    }
+
+    this.confidenceTrend = normalized;
+    this.manifest.confidenceTrend = cloneConfidenceTrend(normalized);
+  }
+
+  private createAssetName(format: FrameFormat): string {
+    const extension = formatToExtension(format);
+    const index = this.nextIndex + 1;
+    return `${this.prefix}-${index.toString().padStart(6, '0')}.${extension}`;
+  }
+
+  private updateStatistics() {
+    const count = this.manifest.frames.length;
+    if (count === 0) {
+      const emptyHistogram = createEmptyHistogram(
+        this.confidenceHistogram.bucketSize,
+        this.confidenceHistogram.counts.length
+      );
+      this.confidenceHistogram = emptyHistogram;
+      this.manifest.stats = createEmptyStats(emptyHistogram);
+      this.syncConfidenceTrend();
+      return;
+    }
+
+    const latencies = [...this.totalLatencies].sort((a, b) => a - b);
+    const sum = this.totalLatencies.reduce((total, value) => total + value, 0);
+    const average = this.totalLatencies.length ? sum / this.totalLatencies.length : 0;
+    const min = this.totalLatencies.length ? latencies[0] : 0;
+    const max = this.totalLatencies.length ? latencies[latencies.length - 1] : 0;
+    const p95 = this.totalLatencies.length ? percentile(latencies, 0.95) : 0;
+
+    this.manifest.stats = {
+      totalFrames: count,
+      averageTotalLatencyMs: average,
+      minTotalLatencyMs: min,
+      maxTotalLatencyMs: max,
+      p95TotalLatencyMs: p95,
+      lastUpdated: Date.now(),
+      confidenceHistogram: cloneHistogram(this.confidenceHistogram)
+    };
+    this.syncConfidenceTrend();
+  }
+
+  private syncConfidenceTrend(): void {
+    if (this.confidenceTrend && this.confidenceTrend.values.length > 0) {
+      this.manifest.confidenceTrend = cloneConfidenceTrend(this.confidenceTrend);
+    } else {
+      delete this.manifest.confidenceTrend;
+    }
+  }
+
+  private recordConfidence(value: number) {
+    if (!Number.isFinite(value)) {
+      return;
+    }
+    const normalized = clampConfidence(value);
+    const { bucketSize, counts } = this.confidenceHistogram;
+    if (counts.length === 0 || bucketSize <= 0) {
+      return;
+    }
+    let index = Math.floor(normalized / bucketSize);
+    if (normalized >= 1) {
+      index = counts.length - 1;
+    } else {
+      index = Math.min(counts.length - 1, index);
+    }
+    counts[index] += 1;
+    this.confidenceHistogram.totalSamples += 1;
+  }
+}
+
+function createSessionId() {
+  return `${DEFAULT_SESSION_PREFIX}-${Date.now().toString(36)}`;
+}
+
+function createEmptyStats(histogram: ConfidenceHistogram = createEmptyHistogram()): DatasetManifestStatistics {
+  return {
+    totalFrames: 0,
+    averageTotalLatencyMs: 0,
+    p95TotalLatencyMs: 0,
+    minTotalLatencyMs: 0,
+    maxTotalLatencyMs: 0,
+    lastUpdated: Date.now(),
+    confidenceHistogram: cloneHistogram(histogram)
+  };
+}
+
+function formatToExtension(format: FrameFormat): string {
+  switch (format) {
+    case 'image/png':
+      return 'png';
+    case 'image/webp':
+      return 'webp';
+    case 'video/webm':
+      return 'webm';
+    default:
+      return 'bin';
+  }
+}
+
+function computeTotalLatency(envelope: PipelineLatencyEnvelope | undefined): number | null {
+  if (!envelope) {
+    return null;
+  }
+  if (typeof envelope.totalMs === 'number') {
+    return envelope.totalMs;
+  }
+  const parts = [envelope.uniformMs, envelope.captureMs, envelope.encodeMs ?? 0].filter(
+    value => typeof value === 'number' && Number.isFinite(value)
+  ) as number[];
+  if (!parts.length) {
+    return null;
+  }
+  const total = parts.reduce((sum, value) => sum + value, 0);
+  return Number.isFinite(total) ? total : null;
+}
+
+function percentile(sortedValues: number[], percentileRank: number): number {
+  if (!sortedValues.length) {
+    return 0;
+  }
+  const index = Math.min(sortedValues.length - 1, Math.ceil(sortedValues.length * percentileRank) - 1);
+  return sortedValues[index];
+}
+
+function createEmptyHistogram(
+  bucketSize = DEFAULT_CONFIDENCE_BUCKET_SIZE,
+  bucketCount?: number
+): ConfidenceHistogram {
+  const size = Math.max(bucketSize, 1e-6);
+  const count = bucketCount ?? Math.max(1, Math.ceil(1 / size));
+  return { bucketSize: size, counts: new Array(count).fill(0), totalSamples: 0 };
+}
+
+function cloneHistogram(histogram: ConfidenceHistogram): ConfidenceHistogram {
+  return {
+    bucketSize: histogram.bucketSize,
+    counts: [...histogram.counts],
+    totalSamples: histogram.totalSamples
+  };
+}
+
+function normalizeConfidence(value: number | undefined): number | null {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return null;
+  }
+  return clampConfidence(value);
+}
+
+function clampConfidence(value: number): number {
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+  if (value <= 0) {
+    return 0;
+  }
+  if (value >= 1) {
+    return 1;
+  }
+  return value;
+}
+
+function cloneManifest(manifest: DatasetManifest): DatasetManifest {
+  if (typeof globalThis.structuredClone === 'function') {
+    return globalThis.structuredClone(manifest);
+  }
+  return JSON.parse(JSON.stringify(manifest)) as DatasetManifest;
+}
+
+function normalizeTelemetryLog(log: DatasetTelemetryLog): DatasetTelemetryLog {
+  const capacity = normalizeTelemetryCapacity(log.capacity);
+  const events = Array.isArray(log.events)
+    ? log.events
+        .map(normalizeTelemetryEvent)
+        .filter((event): event is TelemetryEvent => event !== null)
+    : [];
+  const trimmed = events.slice(-capacity);
+  const updatedAt = normalizeTimestamp(log.updatedAt) ?? (trimmed.length ? trimmed[trimmed.length - 1].timestamp : Date.now());
+  return {
+    capacity,
+    updatedAt,
+    events: trimmed.map(event => ({
+      ...event,
+      metadata: event.metadata ? cloneMetadata(event.metadata) : undefined
+    }))
+  };
+}
+
+function normalizeTelemetryCapacity(value: unknown): number {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric) || numeric <= 0) {
+    return 1;
+  }
+  return Math.floor(numeric);
+}
+
+function normalizeTelemetryEvent(event: TelemetryEvent | undefined): TelemetryEvent | null {
+  if (!event || typeof event !== 'object') {
+    return null;
+  }
+
+  if (!isTelemetryCategory(event.category)) {
+    return null;
+  }
+
+  if (typeof event.message !== 'string') {
+    return null;
+  }
+
+  const id = Number(event.id);
+  const timestamp = normalizeTimestamp(event.timestamp);
+  if (!Number.isFinite(id) || typeof timestamp !== 'number') {
+    return null;
+  }
+
+  return {
+    id,
+    category: event.category,
+    message: event.message,
+    timestamp,
+    metadata: isPlainRecord(event.metadata) ? cloneMetadata(event.metadata) : undefined
+  };
+}
+
+function normalizeTimestamp(value: unknown): number | null {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric) || numeric <= 0) {
+    return null;
+  }
+  return numeric;
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function cloneMetadata(metadata: Record<string, unknown>): Record<string, unknown> {
+  if (typeof globalThis.structuredClone === 'function') {
+    return globalThis.structuredClone(metadata);
+  }
+  return JSON.parse(JSON.stringify(metadata));
+}
+
+function isTelemetryCategory(value: unknown): value is TelemetryCategory {
+  return value === 'parserator' || value === 'ingestion' || value === 'extrument' || value === 'system';
+}
+
+function normalizeConfidenceTrendState(
+  state: ConfidenceTrendState | null | undefined
+): ConfidenceTrendState | undefined {
+  if (!state) {
+    return undefined;
+  }
+
+  try {
+    const trend = new ConfidenceTrend({ state });
+    const normalized = trend.toJSON();
+    return normalized.samples && normalized.samples.length ? normalized : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function cloneConfidenceTrend(state: ConfidenceTrendState): ConfidenceTrendState {
+  return {
+    values: [...state.values],
+    samples: state.samples?.map(sample => ({
+      value: sample.value,
+      timestamp: sample.timestamp,
+      annotation: sample.annotation
+        ? {
+            profileId: sample.annotation.profileId,
+            profileName: sample.annotation.profileName,
+            confidenceFloor: sample.annotation.confidenceFloor,
+            preprocessors: sample.annotation.preprocessors
+              ? [...sample.annotation.preprocessors]
+              : undefined
+          }
+        : undefined
+    })),
+    maxPoints: state.maxPoints,
+    updatedAt: state.updatedAt
+  };
+}

--- a/src/pipeline/datasetTypes.ts
+++ b/src/pipeline/datasetTypes.ts
@@ -1,0 +1,37 @@
+export type FrameFormat = 'image/png' | 'image/webp' | 'video/webm';
+
+export interface PipelineLatencyEnvelope {
+  /** Time from the originating sensor sample to the uniform upload that consumed it. */
+  uniformMs: number;
+  /** Wall-clock timestamp (performance.now) when the uniform upload completed. */
+  uniformTimestamp?: number;
+  /** Time from the originating sensor sample to when the frame pixels were captured. */
+  captureMs: number;
+  /** Wall-clock timestamp when the capture completed. */
+  captureTimestamp: number;
+  /** Time spent encoding the captured frame. */
+  encodeMs?: number;
+  /** Wall-clock timestamp when encoding finished. */
+  encodeCompletedTimestamp?: number;
+  /** Aggregate end-to-end latency from sensor sample to encoded payload availability. */
+  totalMs?: number;
+}
+
+export interface FrameMetadata {
+  timestamp: number;
+  rotationAngles: [number, number, number, number, number, number];
+  confidence?: number;
+  latency?: PipelineLatencyEnvelope;
+}
+
+export interface FramePayload {
+  width: number;
+  height: number;
+  pixels: Uint8ClampedArray;
+  metadata: FrameMetadata;
+}
+
+export interface EncodedFrame {
+  blob: Blob;
+  metadata: FrameMetadata;
+}

--- a/src/pipeline/datasetWorker.ts
+++ b/src/pipeline/datasetWorker.ts
@@ -1,0 +1,39 @@
+/// <reference lib="webworker" />
+import { encodeFrameToBlob } from './frameEncoding';
+import type { FrameFormat, FramePayload } from './datasetTypes';
+
+interface WorkerRequest {
+  id: number;
+  format: FrameFormat;
+  frame: FramePayload;
+}
+
+interface WorkerSuccess {
+  id: number;
+  success: true;
+  blob: Blob;
+}
+
+interface WorkerFailure {
+  id: number;
+  success: false;
+  error: string;
+}
+
+type WorkerResponse = WorkerSuccess | WorkerFailure;
+
+const ctx: DedicatedWorkerGlobalScope = self as unknown as DedicatedWorkerGlobalScope;
+
+ctx.onmessage = async event => {
+  const message = event.data as WorkerRequest;
+  try {
+    const blob = await encodeFrameToBlob(message.frame, message.format);
+    post({ id: message.id, success: true, blob });
+  } catch (error) {
+    post({ id: message.id, success: false, error: (error as Error).message });
+  }
+};
+
+function post(response: WorkerResponse) {
+  ctx.postMessage(response);
+}

--- a/src/pipeline/focusDirector.test.ts
+++ b/src/pipeline/focusDirector.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { FocusDirector } from './focusDirector';
+import { RotationBus } from './rotationBus';
+import type { GeometryDescriptor } from '../geometry/types';
+import type { GeometryId } from './geometryCatalog';
+
+class FakeGeometryController {
+  active: GeometryId | null = null;
+  constructor(private readonly geometries: GeometryDescriptor[]) {}
+  getAvailableGeometries() {
+    return this.geometries;
+  }
+  setActiveGeometry(id: GeometryId) {
+    this.active = id;
+  }
+}
+
+describe('FocusDirector', () => {
+  it('applies focus hints and falls back on timeout', () => {
+    const geometries = [{
+      id: 'tesseract',
+      name: 'Tesseract',
+      data: {
+        positions: new Float32Array(0),
+        indices: new Uint16Array(0),
+        drawMode: 0,
+        vertexStride: 4,
+        topology: { vertices: 16, edges: 32, faces: 24, cells: 8 }
+      }
+    } as GeometryDescriptor];
+    const controller = new FakeGeometryController(geometries);
+    const bus = new RotationBus();
+    const director = new FocusDirector(controller as any, bus, { timeoutMs: 10 });
+
+    director.ingestHint({ geometry: 'tesseract', rotationBias: { xy: 0.5 } });
+    bus.push({
+      xy: 0,
+      xz: 0,
+      yz: 0,
+      xw: 0,
+      yw: 0,
+      zw: 0,
+      timestamp: performance.now(),
+      confidence: 0.5
+    });
+    director.update(performance.now());
+    expect(controller.active).toBe('tesseract');
+
+    director.update(performance.now() + 20);
+    expect(controller.active).toBe('tesseract');
+  });
+});

--- a/src/pipeline/focusDirector.ts
+++ b/src/pipeline/focusDirector.ts
@@ -1,0 +1,86 @@
+import type { GeometryId } from './geometryCatalog';
+import type { GeometryController } from './geometryController';
+import type { RotationBus } from './rotationBus';
+import type { RotationAngles, RotationSnapshot } from '../core/rotationUniforms';
+
+export interface FocusHint {
+  geometry?: GeometryId;
+  rotationBias?: Partial<RotationAngles>;
+  confidenceBoost?: number;
+}
+
+export interface FocusDirectorOptions {
+  fallbackGeometry?: GeometryId;
+  timeoutMs?: number;
+}
+
+export class FocusDirector {
+  private lastHintAt = 0;
+  private readonly timeoutMs: number;
+  private readonly fallbackGeometry: GeometryId;
+  private rotationBias: Partial<RotationAngles> = {};
+  private confidenceBoost = 0;
+
+  constructor(
+    private readonly geometryController: GeometryController,
+    private readonly rotationBus: RotationBus,
+    options: FocusDirectorOptions = {}
+  ) {
+    this.timeoutMs = options.timeoutMs ?? 5000;
+    this.fallbackGeometry = options.fallbackGeometry ?? 'tesseract';
+  }
+
+  ingestHint(hint: FocusHint) {
+    this.lastHintAt = performance.now();
+    if (hint.geometry) {
+      this.geometryController.setActiveGeometry(hint.geometry);
+    }
+    if (hint.rotationBias) {
+      this.rotationBias = { ...hint.rotationBias };
+    }
+    if (typeof hint.confidenceBoost === 'number') {
+      this.confidenceBoost = hint.confidenceBoost;
+    }
+  }
+
+  update(snapshotTime = performance.now()) {
+    if (snapshotTime - this.lastHintAt > this.timeoutMs) {
+      this.geometryController.setActiveGeometry(this.fallbackGeometry);
+      this.rotationBias = {};
+      this.confidenceBoost = 0;
+      this.lastHintAt = snapshotTime;
+    }
+
+    const latest = this.rotationBus.getLatest({
+      xy: 0,
+      xz: 0,
+      yz: 0,
+      xw: 0,
+      yw: 0,
+      zw: 0,
+      timestamp: snapshotTime,
+      confidence: 1
+    });
+
+    let mutated = false;
+    const nextSnapshot: RotationSnapshot = { ...latest };
+    if (this.rotationBias) {
+      (Object.keys(this.rotationBias) as (keyof RotationAngles)[]).forEach(plane => {
+        const value = this.rotationBias[plane];
+        if (typeof value === 'number') {
+          nextSnapshot[plane] += value;
+          mutated = true;
+        }
+      });
+    }
+    if (this.confidenceBoost !== 0) {
+      nextSnapshot.confidence = Math.min(1, latest.confidence + this.confidenceBoost);
+      mutated = true;
+    }
+
+    if (mutated) {
+      nextSnapshot.timestamp = snapshotTime;
+      this.rotationBus.push({ ...nextSnapshot });
+    }
+  }
+}

--- a/src/pipeline/frameEncoding.ts
+++ b/src/pipeline/frameEncoding.ts
@@ -1,0 +1,34 @@
+import type { FrameFormat, FramePayload } from './datasetTypes';
+
+export async function encodeFrameToBlob(frame: FramePayload, format: FrameFormat): Promise<Blob> {
+  if (typeof OffscreenCanvas !== 'undefined') {
+    const canvas = new OffscreenCanvas(frame.width, frame.height);
+    const context = canvas.getContext('2d');
+    if (!context) {
+      throw new Error('Unable to allocate offscreen context');
+    }
+    const pixels =
+      frame.pixels instanceof Uint8ClampedArray ? frame.pixels : new Uint8ClampedArray(frame.pixels);
+    const imageData = context.createImageData(frame.width, frame.height);
+    imageData.data.set(pixels);
+    context.putImageData(imageData, 0, 0);
+    return canvas.convertToBlob({ type: format });
+  }
+
+  const payload = {
+    format,
+    width: frame.width,
+    height: frame.height,
+    metadata: frame.metadata,
+    checksum: checksum(frame.pixels)
+  };
+  return new Blob([JSON.stringify(payload)], { type: 'application/json' });
+}
+
+export function checksum(pixels: Uint8ClampedArray): number {
+  let sum = 0;
+  for (let i = 0; i < pixels.length; i++) {
+    sum = (sum + pixels[i]) % 65536;
+  }
+  return sum;
+}

--- a/src/pipeline/geometryCatalog.ts
+++ b/src/pipeline/geometryCatalog.ts
@@ -1,8 +1,9 @@
+import { SixHundredCellGeometry } from '../geometry/sixHundredCell';
 import { TesseractGeometry } from '../geometry/tesseract';
 import { TwentyFourCellGeometry } from '../geometry/twentyFourCell';
 import type { GeometryData, GeometryDescriptor } from '../geometry/types';
 
-export type GeometryId = 'tesseract' | 'twentyFourCell';
+export type GeometryId = 'tesseract' | 'twentyFourCell' | 'sixHundredCell';
 
 const CATALOG: Record<GeometryId, GeometryDescriptor> = {
   tesseract: {
@@ -14,6 +15,11 @@ const CATALOG: Record<GeometryId, GeometryDescriptor> = {
     id: 'twentyFourCell',
     name: '24-Cell',
     data: TwentyFourCellGeometry
+  },
+  sixHundredCell: {
+    id: 'sixHundredCell',
+    name: '600-Cell',
+    data: SixHundredCellGeometry
   }
 };
 

--- a/src/pipeline/geometryController.ts
+++ b/src/pipeline/geometryController.ts
@@ -1,0 +1,31 @@
+import type { GeometryDescriptor } from '../geometry/types';
+import { getGeometry, listGeometries, type GeometryId } from './geometryCatalog';
+import type { HypercubeCore } from '../core/hypercubeCore';
+
+export class GeometryController {
+  private readonly descriptors: GeometryDescriptor[];
+  private active: GeometryId | null = null;
+
+  constructor(private readonly core: HypercubeCore) {
+    this.descriptors = listGeometries();
+  }
+
+  getAvailableGeometries(): GeometryDescriptor[] {
+    return this.descriptors.slice();
+  }
+
+  getActiveGeometry(): GeometryId | null {
+    return this.active;
+  }
+
+  getDescriptor(id: GeometryId): GeometryDescriptor | undefined {
+    return this.descriptors.find(descriptor => descriptor.id === id);
+  }
+
+  setActiveGeometry(id: GeometryId) {
+    if (this.active === id) return;
+    const geometry = getGeometry(id);
+    this.core.setGeometry(geometry);
+    this.active = id;
+  }
+}

--- a/src/pipeline/haosBridge.test.ts
+++ b/src/pipeline/haosBridge.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it, vi } from 'vitest';
+import { HaosBridge } from './haosBridge';
+import { FocusDirector } from './focusDirector';
+import { RotationBus } from './rotationBus';
+
+const mockFocusDirector = {
+  ingestHint: vi.fn()
+} as unknown as FocusDirector;
+
+describe('HaosBridge', () => {
+  it('dispatches focus profile updates', () => {
+    const bridge = new HaosBridge(mockFocusDirector);
+    const response = bridge.handleRequest({ id: 1, method: 'setFocusProfile', params: { geometry: 'tesseract' } });
+    expect(response.result).toBe('ok');
+  });
+
+  it('returns method not found for unknown calls', () => {
+    const bridge = new HaosBridge(mockFocusDirector);
+    const response = bridge.handleRequest({ id: 2, method: 'unknown' });
+    expect(response.error?.code).toBe(-32601);
+  });
+});

--- a/src/pipeline/haosBridge.ts
+++ b/src/pipeline/haosBridge.ts
@@ -1,0 +1,40 @@
+import type { FocusDirector, FocusHint } from './focusDirector';
+
+export interface JsonRpcRequest {
+  id: string | number;
+  method: string;
+  params?: Record<string, unknown>;
+}
+
+export interface JsonRpcResponse {
+  id: string | number;
+  result?: unknown;
+  error?: { code: number; message: string };
+}
+
+export class HaosBridge {
+  constructor(private readonly focusDirector: FocusDirector) {}
+
+  handleRequest(request: JsonRpcRequest): JsonRpcResponse {
+    try {
+      switch (request.method) {
+        case 'setFocusProfile':
+          this.applyFocus(request.params as FocusHint);
+          return { id: request.id, result: 'ok' };
+        case 'queueRotationScript':
+          return { id: request.id, result: 'queued' };
+        case 'requestSnapshot':
+          return { id: request.id, result: { timestamp: performance.now() } };
+        default:
+          return { id: request.id, error: { code: -32601, message: 'Method not found' } };
+      }
+    } catch (error) {
+      return { id: request.id, error: { code: -32000, message: (error as Error).message } };
+    }
+  }
+
+  private applyFocus(params?: FocusHint) {
+    if (!params) return;
+    this.focusDirector.ingestHint(params);
+  }
+}

--- a/src/pipeline/latencyTracker.test.ts
+++ b/src/pipeline/latencyTracker.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import type { UniformSyncMetrics } from '../core/uniformSyncQueue';
+import { LatencyTracker } from './latencyTracker';
+
+const baseMetrics: UniformSyncMetrics = {
+  enqueued: 0,
+  uploads: 0,
+  skipped: 0,
+  lastUploadTime: 0,
+  lastSnapshotTimestamp: 0,
+  lastUploadLatency: 0
+};
+
+describe('LatencyTracker', () => {
+  it('records uniform and capture latencies without duplicating samples', () => {
+    const tracker = new LatencyTracker(4);
+    tracker.recordUniform({ ...baseMetrics, uploads: 1, lastUploadTime: 10, lastSnapshotTimestamp: 2, lastUploadLatency: 8 });
+    tracker.recordUniform({ ...baseMetrics, uploads: 1, lastUploadTime: 10, lastSnapshotTimestamp: 2, lastUploadLatency: 8 });
+    tracker.recordUniform({ ...baseMetrics, uploads: 2, lastUploadTime: 22, lastSnapshotTimestamp: 5, lastUploadLatency: 17 });
+
+    tracker.recordCapture(5, 25);
+    tracker.recordCapture(5, 30);
+    tracker.recordCapture(10, 32);
+
+    const metrics = tracker.getMetrics();
+    expect(metrics.uniformAvgMs).toBeCloseTo((8 + 17) / 2);
+    expect(metrics.uniformMaxMs).toBeCloseTo(17);
+    expect(metrics.captureAvgMs).toBeCloseTo(((25 - 5) + (32 - 10)) / 2);
+    expect(metrics.captureMaxMs).toBeCloseTo(22);
+  });
+
+  it('tracks encode latency samples', () => {
+    const tracker = new LatencyTracker(3);
+    tracker.recordEncode(4);
+    tracker.recordEncode(6);
+    tracker.recordEncode(8);
+    tracker.recordEncode(10);
+
+    const metrics = tracker.getMetrics();
+    expect(metrics.encodeAvgMs).toBeCloseTo((6 + 8 + 10) / 3);
+    expect(metrics.encodeMaxMs).toBeCloseTo(10);
+  });
+});

--- a/src/pipeline/latencyTracker.ts
+++ b/src/pipeline/latencyTracker.ts
@@ -1,0 +1,105 @@
+import type { UniformSyncMetrics } from '../core/uniformSyncQueue';
+
+interface RollingStats {
+  push(value: number): void;
+  average(): number;
+  max(): number;
+}
+
+class FixedWindowStats implements RollingStats {
+  private readonly values: number[] = [];
+  private total = 0;
+
+  constructor(private readonly windowSize = 32) {}
+
+  push(value: number) {
+    if (!Number.isFinite(value) || value < 0) {
+      return;
+    }
+    this.values.push(value);
+    this.total += value;
+    if (this.values.length > this.windowSize) {
+      const removed = this.values.shift();
+      if (removed !== undefined) {
+        this.total -= removed;
+      }
+    }
+  }
+
+  average(): number {
+    if (this.values.length === 0) {
+      return 0;
+    }
+    return this.total / this.values.length;
+  }
+
+  max(): number {
+    if (this.values.length === 0) {
+      return 0;
+    }
+    return Math.max(...this.values);
+  }
+}
+
+export interface PipelineLatencyMetrics {
+  uniformAvgMs: number;
+  uniformMaxMs: number;
+  captureAvgMs: number;
+  captureMaxMs: number;
+  encodeAvgMs: number;
+  encodeMaxMs: number;
+}
+
+export class LatencyTracker {
+  private readonly uniformStats: RollingStats;
+  private readonly captureStats: RollingStats;
+  private readonly encodeStats: RollingStats;
+  private lastUniformUploads = 0;
+  private lastUniformTime = 0;
+  private lastCaptureTimestamp = 0;
+
+  constructor(windowSize = 32) {
+    this.uniformStats = new FixedWindowStats(windowSize);
+    this.captureStats = new FixedWindowStats(windowSize);
+    this.encodeStats = new FixedWindowStats(windowSize);
+  }
+
+  recordUniform(metrics: UniformSyncMetrics) {
+    if (metrics.uploads === this.lastUniformUploads) {
+      return;
+    }
+    this.lastUniformUploads = metrics.uploads;
+    if (metrics.lastUploadTime === this.lastUniformTime) {
+      return;
+    }
+    this.lastUniformTime = metrics.lastUploadTime;
+    const latency = metrics.lastUploadLatency;
+    if (metrics.lastSnapshotTimestamp > 0 && latency >= 0) {
+      this.uniformStats.push(latency);
+    }
+  }
+
+  recordCapture(snapshotTimestamp: number, captureTime: number) {
+    if (snapshotTimestamp <= this.lastCaptureTimestamp) {
+      return;
+    }
+    this.lastCaptureTimestamp = snapshotTimestamp;
+    const latency = Math.max(0, captureTime - snapshotTimestamp);
+    this.captureStats.push(latency);
+  }
+
+  recordEncode(latencyMs: number) {
+    this.encodeStats.push(latencyMs);
+  }
+
+  getMetrics(): PipelineLatencyMetrics {
+    return {
+      uniformAvgMs: this.uniformStats.average(),
+      uniformMaxMs: this.uniformStats.max(),
+      captureAvgMs: this.captureStats.average(),
+      captureMaxMs: this.captureStats.max(),
+      encodeAvgMs: this.encodeStats.average(),
+      encodeMaxMs: this.encodeStats.max()
+    };
+  }
+}

--- a/src/pipeline/projectionBridge.test.ts
+++ b/src/pipeline/projectionBridge.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { configureProjection } from './projectionBridge';
+import { vec4 } from 'gl-matrix';
+
+describe('ProjectionBridge', () => {
+  it('provides orthographic projection identity', () => {
+    const { project } = configureProjection('orthographic');
+    const input = vec4.fromValues(1, 2, 3, 4);
+    const result = project(input);
+    expect(Array.from(result)).toEqual([1, 2, 3]);
+  });
+
+  it('applies perspective depth scaling', () => {
+    const { project } = configureProjection('perspective', { distance: 5 });
+    const input = vec4.fromValues(1, 1, 1, 1);
+    const result = project(input);
+    expect(result[0]).toBeCloseTo(1 / 4);
+    expect(result[2]).toBeCloseTo(1 / 4);
+  });
+});

--- a/src/pipeline/projectionBridge.ts
+++ b/src/pipeline/projectionBridge.ts
@@ -1,0 +1,73 @@
+import type { vec4, vec3 } from 'gl-matrix';
+import { vec3 as Vec3 } from 'gl-matrix';
+
+export type ProjectionMode = 'perspective' | 'stereographic' | 'orthographic';
+
+export interface ProjectionParameters {
+  distance?: number;
+  focalLength?: number;
+  stereographicScale?: number;
+}
+
+export interface ProjectionConfig {
+  mode: ProjectionMode;
+  shaderSnippet: string;
+  project: (input: vec4) => vec3;
+}
+
+export function configureProjection(mode: ProjectionMode, parameters: ProjectionParameters = {}): ProjectionConfig {
+  switch (mode) {
+    case 'perspective':
+      return {
+        mode,
+        shaderSnippet: perspectiveSnippet(parameters.distance ?? 3.0),
+        project: vector => projectPerspective(vector, parameters.distance ?? 3.0)
+      };
+    case 'stereographic':
+      return {
+        mode,
+        shaderSnippet: stereographicSnippet(parameters.stereographicScale ?? 1.0),
+        project: vector => projectStereographic(vector, parameters.stereographicScale ?? 1.0)
+      };
+    case 'orthographic':
+    default:
+      return {
+        mode: 'orthographic',
+        shaderSnippet: orthographicSnippet(),
+        project: vector => Vec3.fromValues(vector[0], vector[1], vector[2])
+      };
+  }
+}
+
+function perspectiveSnippet(distance: number): string {
+  return `
+vec3 project4Dto3D(vec4 v) {
+  float depth = max(${distance.toFixed(3)} - v.w, 0.1);
+  return v.xyz / depth;
+}`.trim();
+}
+
+function stereographicSnippet(scale: number): string {
+  return `
+vec3 project4Dto3D(vec4 v) {
+  float denom = max(${scale.toFixed(3)} - v.w, 0.1);
+  return v.xyz / denom;
+}`.trim();
+}
+
+function orthographicSnippet(): string {
+  return `
+vec3 project4Dto3D(vec4 v) {
+  return v.xyz;
+}`.trim();
+}
+
+function projectPerspective(vector: vec4, distance: number): vec3 {
+  const depth = Math.max(distance - vector[3], 0.1);
+  return Vec3.fromValues(vector[0] / depth, vector[1] / depth, vector[2] / depth);
+}
+
+function projectStereographic(vector: vec4, scale: number): vec3 {
+  const denom = Math.max(scale - vector[3], 0.1);
+  return Vec3.fromValues(vector[0] / denom, vector[1] / denom, vector[2] / denom);
+}

--- a/src/pipeline/pspStream.test.ts
+++ b/src/pipeline/pspStream.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { LocalPspStream } from './pspStream';
+
+const mockBlob = new Blob(['test'], { type: 'text/plain' });
+
+describe('LocalPspStream', () => {
+  it('notifies subscribers of frames', async () => {
+    const stream = new LocalPspStream();
+    let received = 0;
+    stream.subscribe(frame => {
+      received += frame.metadata.timestamp;
+    });
+    stream.publish({
+      blob: mockBlob,
+      metadata: { timestamp: 2, rotationAngles: [0, 0, 0, 0, 0, 0] }
+    });
+    expect(received).toBe(2);
+  });
+});

--- a/src/pipeline/pspStream.ts
+++ b/src/pipeline/pspStream.ts
@@ -1,0 +1,25 @@
+import type { EncodedFrame } from './datasetExport';
+
+export interface PspSubscriber {
+  (frame: EncodedFrame): void;
+}
+
+export interface PspStream {
+  subscribe(listener: PspSubscriber): () => void;
+  publish(frame: EncodedFrame): void;
+}
+
+export class LocalPspStream implements PspStream {
+  private readonly listeners = new Set<PspSubscriber>();
+
+  subscribe(listener: PspSubscriber): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  publish(frame: EncodedFrame): void {
+    for (const listener of this.listeners) {
+      listener(frame);
+    }
+  }
+}

--- a/src/pipeline/telemetryLoom.test.ts
+++ b/src/pipeline/telemetryLoom.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from 'vitest';
+import { TelemetryLoom } from './telemetryLoom';
+
+describe('TelemetryLoom', () => {
+  it('retains the most recent events up to capacity', () => {
+    const loom = new TelemetryLoom(3);
+    loom.record({ category: 'system', message: 'A', timestamp: 1 });
+    loom.record({ category: 'system', message: 'B', timestamp: 2 });
+    loom.record({ category: 'system', message: 'C', timestamp: 3 });
+    loom.record({ category: 'system', message: 'D', timestamp: 4 });
+
+    const events = loom.list();
+    expect(events).toHaveLength(3);
+    expect(events.map(event => event.message)).toEqual(['B', 'C', 'D']);
+  });
+
+  it('clones metadata to avoid external mutation', () => {
+    const loom = new TelemetryLoom();
+    const metadata = { profileId: 'alpha' };
+    loom.record({ category: 'parserator', message: 'Profile', metadata, timestamp: 10 });
+    metadata.profileId = 'beta';
+
+    const [event] = loom.list();
+    expect(event.metadata).toEqual({ profileId: 'alpha' });
+  });
+
+  it('uses current time when timestamp is omitted', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2024-01-02T03:04:05Z'));
+
+    const loom = new TelemetryLoom(2);
+    loom.record({ category: 'system', message: 'Auto time' });
+    const [event] = loom.list();
+    expect(event.timestamp).toBeCloseTo(Date.now(), 1);
+
+    vi.useRealTimers();
+  });
+
+  it('creates snapshots and hydrates from persisted logs', () => {
+    const loom = new TelemetryLoom(4);
+    loom.record({ category: 'parserator', message: 'Profile selected', timestamp: 100 });
+    loom.record({
+      category: 'system',
+      message: 'Hydrated',
+      timestamp: 200,
+      metadata: { source: 'localStorage' }
+    });
+
+    const snapshot = loom.snapshot();
+    expect(snapshot.capacity).toBe(4);
+    expect(snapshot.events).toHaveLength(2);
+
+    const hydrated = new TelemetryLoom(3);
+    hydrated.hydrate(snapshot);
+    const events = hydrated.list();
+    expect(events).toHaveLength(2);
+    expect(events[1].metadata).toEqual({ source: 'localStorage' });
+
+    hydrated.record({ category: 'system', message: 'New event', timestamp: 300 });
+    const ids = hydrated.list().map(event => event.id);
+    expect(ids[ids.length - 1]).toBeGreaterThan(snapshot.events[snapshot.events.length - 1].id);
+
+    hydrated.hydrate(null);
+    expect(hydrated.list()).toHaveLength(0);
+  });
+});

--- a/src/pipeline/telemetryLoom.ts
+++ b/src/pipeline/telemetryLoom.ts
@@ -1,0 +1,138 @@
+export type TelemetryCategory = 'parserator' | 'ingestion' | 'extrument' | 'system';
+
+export interface TelemetryEventInput {
+  category: TelemetryCategory;
+  message: string;
+  metadata?: Record<string, unknown>;
+  timestamp?: number;
+}
+
+export interface TelemetryEvent {
+  id: number;
+  category: TelemetryCategory;
+  message: string;
+  timestamp: number;
+  metadata?: Record<string, unknown>;
+}
+
+export interface TelemetryLogSnapshot {
+  capacity: number;
+  updatedAt: number;
+  events: TelemetryEvent[];
+}
+
+export class TelemetryLoom {
+  private readonly capacity: number;
+  private events: TelemetryEvent[] = [];
+  private counter = 0;
+
+  constructor(capacity = 120) {
+    this.capacity = Math.max(1, capacity);
+  }
+
+  record(event: TelemetryEventInput): TelemetryEvent[] {
+    const entry: TelemetryEvent = {
+      id: ++this.counter,
+      category: event.category,
+      message: event.message,
+      timestamp: event.timestamp ?? now(),
+      metadata: event.metadata ? cloneMetadata(event.metadata) : undefined
+    };
+    this.events = [...this.events.slice(-(this.capacity - 1)), entry];
+    return this.list();
+  }
+
+  list(): TelemetryEvent[] {
+    return this.events.map(event => ({
+      ...event,
+      metadata: event.metadata ? cloneMetadata(event.metadata) : undefined
+    }));
+  }
+
+  snapshot(): TelemetryLogSnapshot {
+    const events = this.list();
+    const updatedAt = events.length ? events[events.length - 1].timestamp : Date.now();
+    return {
+      capacity: this.capacity,
+      updatedAt,
+      events
+    };
+  }
+
+  hydrate(snapshot: TelemetryLogSnapshot | null | undefined): void {
+    if (!snapshot) {
+      this.events = [];
+      this.counter = 0;
+      return;
+    }
+
+    const limit = Math.max(1, Math.min(this.capacity, Math.floor(snapshot.capacity) || this.capacity));
+    const sanitized = Array.isArray(snapshot.events)
+      ? snapshot.events
+          .map(normalizeHydratedEvent)
+          .filter((event): event is TelemetryEvent => event !== null)
+      : [];
+
+    const trimmed = sanitized.slice(-limit);
+    this.events = trimmed.map(event => ({
+      ...event,
+      metadata: event.metadata ? cloneMetadata(event.metadata) : undefined
+    }));
+    this.counter = this.events.reduce((max, event) => Math.max(max, event.id), 0);
+  }
+
+  getCapacity(): number {
+    return this.capacity;
+  }
+
+  clear(): void {
+    this.events = [];
+  }
+}
+
+function now(): number {
+  return Date.now();
+}
+
+function cloneMetadata(metadata: Record<string, unknown>): Record<string, unknown> {
+  if (typeof structuredClone === 'function') {
+    return structuredClone(metadata);
+  }
+  return JSON.parse(JSON.stringify(metadata));
+}
+
+function normalizeHydratedEvent(event: TelemetryEvent | undefined): TelemetryEvent | null {
+  if (!event || typeof event !== 'object') {
+    return null;
+  }
+
+  const id = Number(event.id);
+  const timestamp = Number(event.timestamp);
+  if (!Number.isFinite(id) || !Number.isFinite(timestamp)) {
+    return null;
+  }
+
+  if (typeof event.message !== 'string') {
+    return null;
+  }
+
+  if (!isTelemetryCategory(event.category)) {
+    return null;
+  }
+
+  return {
+    id,
+    category: event.category,
+    message: event.message,
+    timestamp,
+    metadata: isPlainRecord(event.metadata) ? cloneMetadata(event.metadata) : undefined
+  };
+}
+
+function isTelemetryCategory(value: unknown): value is TelemetryCategory {
+  return value === 'parserator' || value === 'ingestion' || value === 'extrument' || value === 'system';
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}


### PR DESCRIPTION
## Summary
- add buffer-friendly overloads for `composeDualQuaternion`/`applyDualQuaternionRotation` so callers can reuse allocations while keeping parity with sequential SO(4) rotations
- share scratch state inside the SO(4) matrix builders and dual-quaternion rotator to avoid transient objects during matrix synthesis
- document the new dual-quaternion reuse path in the rotor pipeline overview for future staging references

## Testing
- npm test -- --run
- npm run typecheck


------
https://chatgpt.com/codex/tasks/task_e_68d5c4f267208329a9714855d5f3d9b1